### PR TITLE
fix: correct Instagram handle on course page

### DIFF
--- a/src/app/course/page.tsx
+++ b/src/app/course/page.tsx
@@ -597,7 +597,7 @@ export default function CursorCrashCoursePage() {
               </svg>
             </a>
             <a
-              href="https://www.instagram.com/shawn.builds"
+              href="https://www.instagram.com/shawnbuilds"
               target="_blank"
               rel="noopener noreferrer"
               className="transition-colors hover:text-yellow"


### PR DESCRIPTION
## Bug

The Instagram link on the course page pointed to `@shawn.builds` (with a dot) instead of the correct handle `@shawnbuilds`.

Reported via Slack #bugs channel.

## Change

- `src/app/course/page.tsx` line 600: `shawn.builds` → `shawnbuilds`