### PR TITLE
Add /supabase-clone pricing page

### DIFF
--- a/src/app/supabase-clone/page.tsx
+++ b/src/app/supabase-clone/page.tsx
@@ -1,0 +1,620 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  plans,
+  computeRows,
+  diskTiers,
+  addons,
+  comparison,
+  faqs,
+  type Cell,
+} from "./pricing-data";
+
+export const metadata: Metadata = {
+  title: "Pricing & Fees | Supabase Clone",
+  description:
+    "A recreation of the Supabase pricing page. Start building for free, collaborate with a team, then scale to millions of users.",
+};
+
+const BRAND = "#3ECF8E";
+
+function BoltMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M13.5 2 4 14h6.5L10.5 22 20 10h-6.5L13.5 2Z"
+        fill={BRAND}
+        stroke={BRAND}
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-label="Included">
+      <circle cx="12" cy="12" r="11" fill="rgba(62,207,142,0.15)" />
+      <path
+        d="M7 12.5 10.5 16 17 8.5"
+        stroke={BRAND}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CrossIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-label="Not included">
+      <path
+        d="M7 7l10 10M17 7L7 17"
+        stroke="#4d4d4d"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function Nav() {
+  const links = ["Product", "Developers", "Enterprise", "Pricing", "Docs", "Blog"];
+  return (
+    <nav className="sticky top-0 z-50 border-b border-[#2e2e2e] bg-[#121212]/90 backdrop-blur-md">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
+        <div className="flex items-center gap-8">
+          <Link href="/supabase-clone" className="flex items-center gap-2">
+            <BoltMark className="h-6 w-6" />
+            <span className="text-lg font-semibold tracking-tight text-white">
+              supabase
+            </span>
+          </Link>
+          <div className="hidden items-center gap-1 lg:flex">
+            {links.map((link) => (
+              <a
+                key={link}
+                href="#"
+                className={`rounded px-3 py-2 text-sm transition-colors hover:text-white ${
+                  link === "Pricing" ? "text-white" : "text-[#b4b4b4]"
+                }`}
+              >
+                {link}
+              </a>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <a
+            href="#"
+            className="hidden rounded-md border border-[#3e3e3e] bg-[#1c1c1c] px-3 py-1.5 text-sm text-white transition-colors hover:border-[#5e5e5e] sm:block"
+          >
+            Sign in
+          </a>
+          <a
+            href="#plans"
+            className="rounded-md border border-[#34b27b] bg-[#2e9e6b] px-3 py-1.5 text-sm text-white transition-colors hover:bg-[#34b27b]"
+          >
+            Start your project
+          </a>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 pb-12 pt-16 text-center sm:pt-24">
+      <p className="mb-4 text-base font-medium" style={{ color: BRAND }}>
+        Pricing
+      </p>
+      <h1 className="mx-auto max-w-3xl text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+        Predictable pricing,
+        <br className="hidden sm:block" /> designed to scale
+      </h1>
+      <p className="mx-auto mt-5 max-w-xl text-lg text-[#b4b4b4]">
+        Start building for free, collaborate with your team, then scale to
+        millions of users.
+      </p>
+    </section>
+  );
+}
+
+function PlanCards() {
+  return (
+    <section id="plans" className="mx-auto max-w-7xl px-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {plans.map((plan) => (
+          <div
+            key={plan.name}
+            className={`flex flex-col rounded-xl border bg-[#1c1c1c] ${
+              plan.highlight ? "border-[#3ECF8E]" : "border-[#2e2e2e]"
+            }`}
+          >
+            <div className="border-b border-[#2e2e2e] px-6 pb-6 pt-6">
+              <div className="flex items-center justify-between">
+                <h3
+                  className="text-xl font-medium"
+                  style={{ color: plan.highlight ? BRAND : "#fff" }}
+                >
+                  {plan.name}
+                </h3>
+                {plan.highlight && (
+                  <span className="rounded-md bg-[#3ECF8E]/10 px-2.5 py-1 text-xs font-medium leading-4 text-[#3ECF8E]">
+                    Most Popular
+                  </span>
+                )}
+              </div>
+              <p className="mt-3 min-h-[60px] text-sm text-[#b4b4b4]">
+                {plan.description}
+              </p>
+              <div className="mt-4 flex items-end gap-2">
+                <div>
+                  {plan.priceLabel && (
+                    <p className="text-xs uppercase tracking-wide text-[#707070]">
+                      {plan.priceLabel}
+                    </p>
+                  )}
+                  <div className="flex items-end gap-1.5">
+                    <span className="text-4xl font-medium text-white">
+                      {plan.price}
+                    </span>
+                    {plan.priceUnit && (
+                      <span className="mb-1.5 text-sm text-[#707070]">
+                        {plan.priceUnit}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <a
+                href="#"
+                className={`mt-5 block w-full rounded-md border px-4 py-2 text-center text-sm transition-colors ${
+                  plan.ctaVariant === "brand"
+                    ? "border-[#34b27b] bg-[#2e9e6b] text-white hover:bg-[#34b27b]"
+                    : "border-[#3e3e3e] bg-[#262626] text-white hover:border-[#5e5e5e]"
+                }`}
+              >
+                {plan.cta}
+              </a>
+            </div>
+            <div className="flex flex-1 flex-col px-6 py-6">
+              {plan.featuresIntro && (
+                <p className="mb-4 text-sm text-[#b4b4b4]">{plan.featuresIntro}</p>
+              )}
+              <ul className="flex-1 space-y-2.5">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex items-start gap-2.5">
+                    <CheckIcon className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span className="text-sm text-[#e0e0e0]">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              {plan.footer && (
+                <p className="mt-6 border-t border-[#2e2e2e] pt-4 text-xs leading-relaxed text-[#707070]">
+                  {plan.footer}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BillingExplainer() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 py-20">
+      <div className="grid grid-cols-1 gap-10 rounded-xl border border-[#2e2e2e] bg-[#1c1c1c] p-8 lg:grid-cols-2 lg:p-12">
+        <div>
+          <p className="mb-3 text-sm font-medium" style={{ color: BRAND }}>
+            Usage-based billing
+          </p>
+          <h2 className="text-2xl font-medium text-white sm:text-3xl">
+            How billing works
+          </h2>
+          <p className="mt-4 text-[#b4b4b4]">
+            Supabase uses organization-based billing. Choose a plan for your
+            organization; each project inside it runs on its own compute
+            instance, billed separately and hourly.
+          </p>
+          <p className="mt-4 text-[#b4b4b4]">
+            Pro and Team plans include{" "}
+            <span className="text-white">$10/month in compute credits</span>,
+            enough to cover one Micro instance. Additional projects each add
+            their own compute cost.
+          </p>
+        </div>
+        <div className="rounded-lg border border-[#2e2e2e] bg-[#121212] p-6">
+          <p className="mb-4 text-sm font-medium text-white">
+            Example: Pro org, 2 projects on Micro compute
+          </p>
+          <dl className="space-y-3 text-sm">
+            {[
+              ["Pro Plan", "$25"],
+              ["Compute — Project 1 (Micro)", "$10"],
+              ["Compute — Project 2 (Micro)", "$10"],
+              ["Compute credits", "-$10"],
+            ].map(([label, value]) => (
+              <div
+                key={label}
+                className="flex items-center justify-between border-b border-[#2e2e2e] pb-3"
+              >
+                <dt className="text-[#b4b4b4]">{label}</dt>
+                <dd className="font-mono text-white">{value}</dd>
+              </div>
+            ))}
+            <div className="flex items-center justify-between pt-1">
+              <dt className="font-medium text-white">Total per month</dt>
+              <dd className="font-mono text-lg font-medium" style={{ color: BRAND }}>
+                $35
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComputeSection() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 pb-20">
+      <div className="mb-8 max-w-2xl">
+        <p className="mb-3 text-sm font-medium" style={{ color: BRAND }}>
+          Compute
+        </p>
+        <h2 className="text-2xl font-medium text-white sm:text-3xl">
+          Scalable compute add-ons
+        </h2>
+        <p className="mt-4 text-[#b4b4b4]">
+          Every project runs on a dedicated compute instance, billed hourly. Pro
+          and Team plans include $10/month in compute credits — enough for one
+          Micro instance.
+        </p>
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-[#2e2e2e]">
+        <table className="w-full min-w-[760px] border-collapse text-sm">
+          <thead>
+            <tr className="bg-[#1c1c1c] text-left text-xs uppercase tracking-wide text-[#707070]">
+              {["Size", "$ / Month", "CPU", "Dedicated", "RAM", "Direct Connections", "Pooler Connections"].map(
+                (heading) => (
+                  <th key={heading} className="px-4 py-3 font-medium">
+                    {heading}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {computeRows.map((row) => (
+              <tr
+                key={row.size}
+                className="border-t border-[#2e2e2e] transition-colors hover:bg-[#1c1c1c]"
+              >
+                <td className="px-4 py-3 font-medium text-white">{row.size}</td>
+                <td className="px-4 py-3 font-mono" style={{ color: BRAND }}>
+                  {row.price}
+                </td>
+                <td className="px-4 py-3 text-[#b4b4b4]">{row.cpu}</td>
+                <td className="px-4 py-3">
+                  {row.dedicated === null ? (
+                    <span className="text-[#b4b4b4]">Custom</span>
+                  ) : row.dedicated ? (
+                    <CheckIcon />
+                  ) : (
+                    <CrossIcon />
+                  )}
+                </td>
+                <td className="px-4 py-3 text-[#b4b4b4]">{row.ram}</td>
+                <td className="px-4 py-3 text-[#b4b4b4]">{row.direct}</td>
+                <td className="px-4 py-3 text-[#b4b4b4]">{row.pooler}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function DiskSection() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 pb-20">
+      <div className="mb-8 max-w-2xl">
+        <p className="mb-3 text-sm font-medium" style={{ color: BRAND }}>
+          Disk
+        </p>
+        <h2 className="text-2xl font-medium text-white sm:text-3xl">
+          Scalable disk storage
+        </h2>
+        <p className="mt-4 text-[#b4b4b4]">
+          Choose the disk that fits your workload — from general purpose to high
+          performance for mission critical applications.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {diskTiers.map((tier) => (
+          <div
+            key={tier.name}
+            className="rounded-xl border border-[#2e2e2e] bg-[#1c1c1c] p-6"
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium text-white">{tier.name}</h3>
+              <span className="rounded-md bg-[#262626] px-2.5 py-1 text-xs text-[#b4b4b4]">
+                Max size: {tier.maxSize}
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-[#707070]">{tier.description}</p>
+            <dl className="mt-5 space-y-3 text-sm">
+              {tier.rows.map(([label, value, extra]) => (
+                <div
+                  key={label}
+                  className="flex items-baseline justify-between gap-4 border-t border-[#2e2e2e] pt-3"
+                >
+                  <dt className="text-[#707070]">{label}</dt>
+                  <dd className="text-right text-[#e0e0e0]">
+                    {value}
+                    {extra && (
+                      <span className="block text-xs text-[#707070]">{extra}</span>
+                    )}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AddonsSection() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 pb-20">
+      <div className="mb-8 max-w-2xl">
+        <p className="mb-3 text-sm font-medium" style={{ color: BRAND }}>
+          Add-ons
+        </p>
+        <h2 className="text-2xl font-medium text-white sm:text-3xl">
+          Fine-tune your project
+        </h2>
+        <p className="mt-4 text-[#b4b4b4]">
+          Level up your Supabase experience with add-ons, available on paid plans.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {addons.map((addon) => (
+          <div
+            key={addon.name}
+            className="rounded-xl border border-[#2e2e2e] bg-[#1c1c1c] p-6 transition-colors hover:border-[#3e3e3e]"
+          >
+            <h3 className="font-medium text-white">{addon.name}</h3>
+            <p className="mt-1 text-sm text-[#707070]">{addon.description}</p>
+            <p className="mt-4 text-sm" style={{ color: BRAND }}>
+              {addon.price}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CellContent({ cell }: { cell: Cell }) {
+  if (cell.type === "check") return <CheckIcon className="h-5 w-5" />;
+  if (cell.type === "cross") return <CrossIcon className="h-5 w-5" />;
+  return (
+    <div>
+      <span className="text-[#e0e0e0]">{cell.value}</span>
+      {cell.sub && <span className="block text-xs text-[#707070]">{cell.sub}</span>}
+    </div>
+  );
+}
+
+function ComparisonSectionTables() {
+  const planMeta = [
+    { name: "Free", price: "$0", cta: "Start for Free" },
+    { name: "Pro", price: "$25", cta: "Get Started" },
+    { name: "Team", price: "$599", cta: "Get Started" },
+    { name: "Enterprise", price: "Custom", cta: "Contact Us" },
+  ];
+  return (
+    <section className="mx-auto max-w-7xl px-6 pb-20">
+      <div className="mb-10 text-center">
+        <h2 className="text-3xl font-medium text-white">Compare Plans</h2>
+        <p className="mt-3 text-[#b4b4b4]">
+          Start with a hobby project, collaborate with a team, and scale to
+          millions of users.
+        </p>
+      </div>
+
+      <div className="sticky top-16 z-40 hidden border-b border-[#2e2e2e] bg-[#121212]/95 backdrop-blur-md lg:block">
+        <div className="grid grid-cols-5 py-4">
+          <div />
+          {planMeta.map((plan) => (
+            <div key={plan.name} className="px-4">
+              <p
+                className="text-lg font-medium"
+                style={{ color: plan.name === "Pro" ? BRAND : "#fff" }}
+              >
+                {plan.name}
+              </p>
+              <p className="mt-0.5 text-sm text-[#707070]">
+                {plan.price === "Custom" ? "Custom" : `From ${plan.price} /month`}
+              </p>
+              <a
+                href="#"
+                className={`mt-2 inline-block rounded-md border px-3 py-1 text-xs transition-colors ${
+                  plan.name === "Pro"
+                    ? "border-[#34b27b] bg-[#2e9e6b] text-white hover:bg-[#34b27b]"
+                    : "border-[#3e3e3e] bg-[#262626] text-white hover:border-[#5e5e5e]"
+                }`}
+              >
+                {plan.cta}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {comparison.map((section) => (
+        <div key={section.category} className="mt-12">
+          <h3
+            className="mb-4 flex items-center gap-2 text-lg font-medium text-white"
+            id={`compare-${section.category.toLowerCase().replace(/\s+/g, "-")}`}
+          >
+            <BoltMark className="h-4 w-4" />
+            {section.category}
+          </h3>
+          <div className="overflow-x-auto rounded-xl border border-[#2e2e2e]">
+            <table className="w-full min-w-[860px] border-collapse text-sm">
+              <thead className="lg:sr-only">
+                <tr className="bg-[#1c1c1c] text-left text-xs uppercase tracking-wide text-[#707070]">
+                  <th className="w-1/5 px-4 py-3 font-medium">Feature</th>
+                  {planMeta.map((plan) => (
+                    <th key={plan.name} className="w-1/5 px-4 py-3 font-medium">
+                      {plan.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {section.rows.map((row) => (
+                  <tr
+                    key={row.feature}
+                    className="border-t border-[#2e2e2e] transition-colors first:border-t-0 hover:bg-[#1c1c1c]"
+                  >
+                    <td className="w-1/5 px-4 py-4 align-top text-[#b4b4b4]">
+                      {row.feature}
+                    </td>
+                    {row.cells.map((cell, i) => (
+                      <td key={i} className="w-1/5 px-4 py-4 align-top">
+                        <CellContent cell={cell} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function FaqSection() {
+  return (
+    <section className="border-t border-[#2e2e2e] bg-[#1c1c1c]/50">
+      <div className="mx-auto max-w-3xl px-6 py-20">
+        <h2 className="text-center text-3xl font-medium text-white">
+          Frequently asked questions
+        </h2>
+        <p className="mt-3 text-center text-[#b4b4b4]">
+          Can&apos;t find the answer to your question? You can always{" "}
+          <a href="#" className="underline transition-colors hover:text-white">
+            contact support
+          </a>
+          .
+        </p>
+        <div className="mt-10 divide-y divide-[#2e2e2e] rounded-xl border border-[#2e2e2e] bg-[#1c1c1c]">
+          {faqs.map((faq) => (
+            <details key={faq.q} className="group px-6 py-4">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-sm font-medium text-white [&::-webkit-details-marker]:hidden">
+                {faq.q}
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  className="h-4 w-4 shrink-0 text-[#707070] transition-transform group-open:rotate-180"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="m6 9 6 6 6-6"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-[#b4b4b4]">{faq.a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CtaFooter() {
+  return (
+    <section className="border-t border-[#2e2e2e]">
+      <div className="mx-auto max-w-7xl px-6 py-20 text-center">
+        <h2 className="text-3xl font-medium text-white">
+          Build in a weekend, scale to millions
+        </h2>
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <a
+            href="#plans"
+            className="rounded-md border border-[#34b27b] bg-[#2e9e6b] px-4 py-2 text-sm text-white transition-colors hover:bg-[#34b27b]"
+          >
+            Start your project
+          </a>
+          <a
+            href="#"
+            className="rounded-md border border-[#3e3e3e] bg-[#262626] px-4 py-2 text-sm text-white transition-colors hover:border-[#5e5e5e]"
+          >
+            Request a demo
+          </a>
+        </div>
+      </div>
+      <footer className="border-t border-[#2e2e2e]">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-8 text-sm text-[#707070] sm:flex-row">
+          <div className="flex items-center gap-2">
+            <BoltMark className="h-5 w-5" />
+            <span className="font-medium text-[#b4b4b4]">supabase</span>
+          </div>
+          <p>
+            Educational clone of{" "}
+            <a
+              href="https://supabase.com/pricing"
+              className="underline transition-colors hover:text-white"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              supabase.com/pricing
+            </a>
+            . Not affiliated with Supabase.
+          </p>
+        </div>
+      </footer>
+    </section>
+  );
+}
+
+export default function SupabaseClonePage() {
+  return (
+    <main className="min-h-screen bg-[#121212] font-sans text-white antialiased">
+      <Nav />
+      <Hero />
+      <PlanCards />
+      <BillingExplainer />
+      <ComputeSection />
+      <DiskSection />
+      <AddonsSection />
+      <ComparisonSectionTables />
+      <FaqSection />
+      <CtaFooter />
+    </main>
+  );
+}

--- a/src/app/supabase-clone/pricing-data.ts
+++ b/src/app/supabase-clone/pricing-data.ts
@@ -1,0 +1,486 @@
+export type Plan = {
+  name: string;
+  description: string;
+  priceLabel: string;
+  price: string;
+  priceUnit?: string;
+  cta: string;
+  ctaVariant: "brand" | "outline";
+  highlight?: boolean;
+  featuresIntro?: string;
+  features: string[];
+  footer?: string;
+};
+
+export const plans: Plan[] = [
+  {
+    name: "Free",
+    description: "Perfect for passion projects & simple websites.",
+    priceLabel: "Free",
+    price: "$0",
+    priceUnit: "/ month",
+    cta: "Start for Free",
+    ctaVariant: "outline",
+    featuresIntro: "Get started with:",
+    features: [
+      "Unlimited API requests",
+      "50,000 monthly active users",
+      "500 MB database size",
+      "Shared CPU • 500 MB RAM",
+      "5 GB egress",
+      "5 GB cached egress",
+      "1 GB file storage",
+      "Community support",
+    ],
+    footer: "Free projects are paused after 1 week of inactivity. Limit of 2 active projects.",
+  },
+  {
+    name: "Pro",
+    description: "For production applications with the power to scale.",
+    priceLabel: "From",
+    price: "$25",
+    priceUnit: "/ month",
+    cta: "Get Started",
+    ctaVariant: "brand",
+    highlight: true,
+    featuresIntro: "Everything in the Free Plan, plus:",
+    features: [
+      "100,000 monthly active users, then $0.00325 per MAU",
+      "8 GB disk size per project, then $0.125 per GB",
+      "250 GB egress, then $0.09 per GB",
+      "250 GB cached egress, then $0.03 per GB",
+      "100 GB file storage, then $0.0213 per GB",
+      "Email support",
+      "Daily backups stored for 7 days",
+      "7-day log retention",
+    ],
+    footer: "Add Log Drains, additional $60 per drain, per project",
+  },
+  {
+    name: "Team",
+    description: "Add features such as SSO, control over backups, and industry certifications.",
+    priceLabel: "From",
+    price: "$599",
+    priceUnit: "/ month",
+    cta: "Get Started",
+    ctaVariant: "outline",
+    featuresIntro: "Everything in the Pro Plan, plus:",
+    features: [
+      "SOC2 & ISO 27001",
+      "Project-scoped and read-only access",
+      "HIPAA available as paid add-on",
+      "SSO for Supabase Dashboard",
+      "Priority email support & SLAs",
+      "Daily backups stored for 14 days",
+      "28-day log retention",
+    ],
+  },
+  {
+    name: "Enterprise",
+    description: "For large-scale applications running Internet-scale workloads.",
+    priceLabel: "",
+    price: "Custom",
+    cta: "Contact Us",
+    ctaVariant: "outline",
+    features: [
+      "Designated Support manager",
+      "Uptime SLAs",
+      "BYO Cloud supported",
+      "24×7×365 premium enterprise support",
+      "Private Slack channel",
+      "Custom Security Questionnaires",
+    ],
+  },
+];
+
+export const computeRows: {
+  size: string;
+  price: string;
+  cpu: string;
+  dedicated: boolean | null;
+  ram: string;
+  direct: string;
+  pooler: string;
+}[] = [
+  { size: "Micro", price: "$10", cpu: "2-core ARM", dedicated: false, ram: "1 GB", direct: "60", pooler: "200" },
+  { size: "Small", price: "$15", cpu: "2-core ARM", dedicated: false, ram: "2 GB", direct: "90", pooler: "400" },
+  { size: "Medium", price: "$60", cpu: "2-core ARM", dedicated: false, ram: "4 GB", direct: "120", pooler: "600" },
+  { size: "Large", price: "$110", cpu: "2-core ARM", dedicated: true, ram: "8 GB", direct: "160", pooler: "800" },
+  { size: "XL", price: "$210", cpu: "4-core ARM", dedicated: true, ram: "16 GB", direct: "240", pooler: "1,000" },
+  { size: "2XL", price: "$410", cpu: "8-core ARM", dedicated: true, ram: "32 GB", direct: "380", pooler: "1,500" },
+  { size: "4XL", price: "$960", cpu: "16-core ARM", dedicated: true, ram: "64 GB", direct: "480", pooler: "3,000" },
+  { size: "8XL", price: "$1,870", cpu: "32-core ARM", dedicated: true, ram: "128 GB", direct: "490", pooler: "6,000" },
+  { size: "12XL", price: "$2,800", cpu: "48-core ARM", dedicated: true, ram: "192 GB", direct: "500", pooler: "9,000" },
+  { size: "16XL", price: "$3,730", cpu: "64-core ARM", dedicated: true, ram: "256 GB", direct: "500", pooler: "12,000" },
+  { size: ">16XL", price: "Contact Us", cpu: "Custom", dedicated: true, ram: "Custom", direct: "Custom", pooler: "Custom" },
+];
+
+export const diskTiers = [
+  {
+    name: "General Purpose",
+    description: "Balance between price and performance",
+    maxSize: "16 TB",
+    rows: [
+      ["Size", "8 GB included", "then $0.125 per GB"],
+      ["IOPS", "3,000 IOPS included", "then $0.024 per IOPS"],
+      ["Throughput", "125 MB/s included", "then $0.095 per MB/s"],
+      ["Durability", "99.9%", ""],
+    ],
+  },
+  {
+    name: "High Performance",
+    description: "For mission critical applications",
+    maxSize: "60 TB",
+    rows: [
+      ["Size", "$0.195 per GB", ""],
+      ["IOPS", "$0.119 per IOPS", ""],
+      ["Throughput", "Scales automatically with IOPS", ""],
+      ["Durability", "99.999%", ""],
+    ],
+  },
+];
+
+export const addons = [
+  {
+    name: "Point-in-Time Recovery",
+    price: "$100 per month per 7 days retention",
+    description: "Roll back to any specific point in time, down to the minute.",
+  },
+  {
+    name: "Custom Domain",
+    price: "$10 per domain per month per project",
+    description: "Use your own domain for a branded experience.",
+  },
+  {
+    name: "Database Branching",
+    price: "$0.01344 per branch, per hour",
+    description: "Test and preview changes in isolated environments.",
+  },
+  {
+    name: "Advanced MFA (Phone)",
+    price: "$75/month first project, then $10/month per project",
+    description: "Add phone-based multi-factor authentication.",
+  },
+  {
+    name: "SAML / SSO Auth",
+    price: "50 MAUs included, then $0.015 per MAU",
+    description: "Single Sign-On for your application's users.",
+  },
+  {
+    name: "Log Drains",
+    price: "$60 per drain/month + $0.20 per million events + $0.09 per GB egress",
+    description: "Send logs to your preferred observability platform.",
+  },
+  {
+    name: "Image Transformations",
+    price: "100 origin images included, then $5 per 1000",
+    description: "Resize and optimize images on the fly.",
+  },
+];
+
+export type Cell =
+  | { type: "check" }
+  | { type: "cross" }
+  | { type: "text"; value: string; sub?: string };
+
+export type ComparisonSection = {
+  category: string;
+  rows: { feature: string; cells: [Cell, Cell, Cell, Cell] }[];
+};
+
+const yes: Cell = { type: "check" };
+const no: Cell = { type: "cross" };
+const t = (value: string, sub?: string): Cell => ({ type: "text", value, sub });
+
+export const comparison: ComparisonSection[] = [
+  {
+    category: "Database",
+    rows: [
+      { feature: "Dedicated Postgres Database", cells: [yes, yes, yes, yes] },
+      { feature: "Unlimited API requests", cells: [yes, yes, yes, yes] },
+      {
+        feature: "Database size",
+        cells: [
+          t("500 MB", "database size per project included"),
+          t("8 GB disk size per project", "then $0.125 per GB"),
+          t("8 GB disk size per project", "then $0.125 per GB"),
+          t("Custom"),
+        ],
+      },
+      { feature: "Advanced disk config", cells: [no, yes, yes, yes] },
+      { feature: "Automatic backups", cells: [no, t("7 days"), t("14 days"), t("Custom")] },
+      {
+        feature: "Point in time recovery",
+        cells: [
+          no,
+          t("$100 per month", "per 7 days retention"),
+          t("$100 per month", "per 7 days retention"),
+          t("$100 per month, per 7 days retention", ">28 days retention available"),
+        ],
+      },
+      {
+        feature: "Pausing",
+        cells: [t("After 1 week of inactivity"), t("Never"), t("Never"), t("Never")],
+      },
+      {
+        feature: "Branching",
+        cells: [no, t("$0.01344 per branch, per hour"), t("$0.01344 per branch, per hour"), t("Custom")],
+      },
+      {
+        feature: "Egress",
+        cells: [
+          t("5 GB included"),
+          t("250 GB included", "then $0.09 per GB"),
+          t("250 GB included", "then $0.09 per GB"),
+          t("Custom"),
+        ],
+      },
+    ],
+  },
+  {
+    category: "Auth",
+    rows: [
+      { feature: "Total Users", cells: [t("Unlimited"), t("Unlimited"), t("Unlimited"), t("Unlimited")] },
+      {
+        feature: "MAUs",
+        cells: [
+          t("50,000 included"),
+          t("100,000 included", "then $0.00325 per MAU"),
+          t("100,000 included", "then $0.00325 per MAU"),
+          t("Custom"),
+        ],
+      },
+      { feature: "User data ownership", cells: [yes, yes, yes, yes] },
+      { feature: "Anonymous Sign-ins", cells: [yes, yes, yes, yes] },
+      { feature: "Social OAuth providers", cells: [yes, yes, yes, yes] },
+      { feature: "Custom SMTP server", cells: [yes, yes, yes, yes] },
+      { feature: "Remove Supabase branding from emails", cells: [no, yes, yes, yes] },
+      { feature: "Auth Audit Logs", cells: [t("1 hour"), t("7 days"), t("28 days"), yes] },
+      { feature: "Basic Multi-Factor Auth", cells: [yes, yes, yes, yes] },
+      {
+        feature: "Advanced Multi-Factor Auth - Phone",
+        cells: [
+          no,
+          t("$75 per month for first project", "then $10 per month per additional project"),
+          t("$75 per month for first project", "then $10 per month per additional project"),
+          t("Custom"),
+        ],
+      },
+      {
+        feature: "Third-Party MAUs",
+        cells: [
+          t("50,000 included"),
+          t("100,000 included", "then $0.00325 per MAU"),
+          t("100,000 included", "then $0.00325 per MAU"),
+          t("Custom"),
+        ],
+      },
+      {
+        feature: "Single Sign-On (SAML 2.0)",
+        cells: [
+          no,
+          t("50 included", "then $0.015 per MAU"),
+          t("50 included", "then $0.015 per MAU"),
+          t("Contact Us"),
+        ],
+      },
+      { feature: "Leaked password protection", cells: [no, yes, yes, yes] },
+      { feature: "Single session per user", cells: [no, yes, yes, yes] },
+      { feature: "Session timeouts", cells: [no, yes, yes, yes] },
+      {
+        feature: "Auth Hooks",
+        cells: [
+          t("Custom Access Token (JWT)", "Send custom email/SMS"),
+          t("Custom Access Token (JWT)", "Send custom email/SMS"),
+          t("All"),
+          t("All"),
+        ],
+      },
+      { feature: "Advanced security features", cells: [no, no, no, t("Contact Us")] },
+    ],
+  },
+  {
+    category: "Storage",
+    rows: [
+      {
+        feature: "Storage",
+        cells: [
+          t("1 GB included"),
+          t("100 GB included", "then $0.0213 per GB"),
+          t("100 GB included", "then $0.0213 per GB"),
+          t("Custom"),
+        ],
+      },
+      {
+        feature: "Cached Egress",
+        cells: [
+          t("5 GB included"),
+          t("250 GB included", "then $0.03 per GB"),
+          t("250 GB included", "then $0.03 per GB"),
+          t("Custom"),
+        ],
+      },
+      { feature: "Custom access controls", cells: [yes, yes, yes, yes] },
+      { feature: "Max file upload size", cells: [t("50 MB"), t("500 GB"), t("500 GB"), t("Custom")] },
+      {
+        feature: "Content Delivery Network",
+        cells: [t("Basic CDN"), t("Smart CDN"), t("Smart CDN"), t("Smart CDN")],
+      },
+      {
+        feature: "Image Transformations",
+        cells: [
+          no,
+          t("100 origin images included", "then $5 per 1000 origin images"),
+          t("100 origin images included", "then $5 per 1000 origin images"),
+          t("Custom"),
+        ],
+      },
+    ],
+  },
+  {
+    category: "Edge Functions",
+    rows: [
+      {
+        feature: "Invocations",
+        cells: [
+          t("500,000 included"),
+          t("2 Million included", "then $2 per 1 Million"),
+          t("2 Million included", "then $2 per 1 Million"),
+          t("Custom"),
+        ],
+      },
+    ],
+  },
+  {
+    category: "Realtime",
+    rows: [
+      { feature: "Postgres Changes", cells: [yes, yes, yes, yes] },
+      {
+        feature: "Concurrent Peak Connections",
+        cells: [
+          t("200 included"),
+          t("500 included", "then $10 per 1000"),
+          t("500 included", "then $10 per 1000"),
+          t("Custom concurrent connections", "and volume discount"),
+        ],
+      },
+      {
+        feature: "Messages Per Month",
+        cells: [
+          t("2 Million included"),
+          t("5 Million included", "then $2.50 per Million"),
+          t("5 Million included", "then $2.50 per Million"),
+          t("Volume discounts on messages"),
+        ],
+      },
+      { feature: "Max Message Size", cells: [t("256 KB"), t("3 MB"), t("3 MB"), t("Custom")] },
+    ],
+  },
+  {
+    category: "Dashboard",
+    rows: [
+      { feature: "Team members", cells: [t("Unlimited"), t("Unlimited"), t("Unlimited"), t("Unlimited")] },
+    ],
+  },
+  {
+    category: "Security and Compliance",
+    rows: [
+      { feature: "BYO cloud", cells: [no, no, no, yes] },
+      {
+        feature: "Log retention (API & Database)",
+        cells: [t("1 day"), t("7 days"), t("28 days"), t("90 days")],
+      },
+      {
+        feature: "Log Drain",
+        cells: [
+          no,
+          t("$60 per drain per month", "+ $0.20 per million events + $0.09 per GB egress"),
+          t("$60 per drain per month", "+ $0.20 per million events + $0.09 per GB egress"),
+          t("Custom"),
+        ],
+      },
+      { feature: "Platform Audit Logs", cells: [no, no, yes, yes] },
+      { feature: "Metrics endpoint", cells: [no, yes, yes, yes] },
+      { feature: "SOC2", cells: [no, no, yes, yes] },
+      { feature: "ISO 27001", cells: [no, no, yes, yes] },
+      { feature: "HIPAA", cells: [no, no, t("Available as paid add-on"), t("Available as paid add-on")] },
+      { feature: "AWS PrivateLink", cells: [no, no, yes, yes] },
+      { feature: "SSO", cells: [no, no, t("Contact Us"), t("Contact Us")] },
+      { feature: "Uptime SLAs", cells: [no, no, no, yes] },
+      {
+        feature: "Access Roles",
+        cells: [
+          t("Owner, Admin, Developer"),
+          t("Owner, Admin, Developer"),
+          t("Owner, Admin, Developer, Read-only", "Predefined project scoped roles"),
+          t("Custom project scoped roles"),
+        ],
+      },
+      { feature: "Vanity URLs", cells: [no, yes, yes, yes] },
+      {
+        feature: "Custom Domains",
+        cells: [
+          no,
+          t("$10 per domain per month", "per project add on"),
+          t("$10 per domain per month", "per project add on"),
+          t("1 included", "additional $10/domain/month"),
+        ],
+      },
+    ],
+  },
+  {
+    category: "Support",
+    rows: [
+      { feature: "Community Support", cells: [yes, yes, yes, yes] },
+      { feature: "Email Support", cells: [no, yes, yes, yes] },
+      { feature: "Email Support SLA", cells: [no, no, yes, yes] },
+      { feature: "Designated support", cells: [no, no, no, yes] },
+      { feature: "On Boarding Support", cells: [no, no, no, yes] },
+      { feature: "Designated Customer Success Team", cells: [no, no, no, yes] },
+      { feature: "Security Questionnaire Help", cells: [no, no, yes, yes] },
+    ],
+  },
+];
+
+export const faqs = [
+  {
+    q: "Can I cap my usage so my bill doesn't run over?",
+    a: "Yes. Spend caps are enabled by default on the Pro Plan. If you want pay-as-you-grow usage beyond plan limits, you can switch the cap off from your dashboard.",
+  },
+  {
+    q: "I'm worried I could end up with a huge bill at the end of the month.",
+    a: "Spend caps are on by default, so you won't be charged for usage beyond plan limits unless you explicitly toggle the cap off in your dashboard.",
+  },
+  {
+    q: "When will I be billed?",
+    a: "The Pro Plan is charged up front on a monthly cycle. Any additional usage charges are billed at the end of each month.",
+  },
+  {
+    q: "Does Supabase charge sales tax, VAT or GST?",
+    a: "Sales tax, VAT, GST, and other indirect taxes are applied where required by law, based on the billing address of your organization.",
+  },
+  {
+    q: "Are you going to change your pricing in the future?",
+    a: "Pricing is currently in Beta and may evolve, but the team is committed to keeping it as developer-friendly as possible.",
+  },
+  {
+    q: "What happens if I cancel my subscription?",
+    a: "Your organization receives credits for the unused portion of the billing month, which can be applied to other projects.",
+  },
+  {
+    q: "Do I get a notification if I am approaching my usage limits?",
+    a: "Yes — you'll receive an email once you're within 20% of your plan limits.",
+  },
+  {
+    q: "What if I need one project for development and one for production?",
+    a: "The Free Plan includes 2 active projects, so you can run a development backend and a production backend side by side. Multi-environment projects are in the works.",
+  },
+  {
+    q: "Can I self-host Supabase for free?",
+    a: "Yes. You can self-host using the Docker setup or the Supabase CLI, and Supabase Studio is included in the Docker setup.",
+  },
+  {
+    q: "Can I pause a free project?",
+    a: "Yes, projects can be paused at any time. The Free Plan allows 2 active projects, but you can keep as many paused projects as you like.",
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recreates the Supabase pricing page as a self-contained route at `/supabase-clone`, styled in Supabase's dark theme with the brand green accent.

### Sections
- Sticky nav with Supabase-style branding and CTA buttons
- Hero ("Predictable pricing, designed to scale")
- Four plan cards (Free, Pro w/ "Most Popular" highlight, Team, Enterprise) with feature lists
- "How billing works" explainer with the $35/month worked example
- Compute add-ons table (Micro through >16XL)
- Disk storage tiers (General Purpose / High Performance)
- Add-ons grid (PITR, Custom Domain, Branching, MFA, SAML/SSO, Log Drains, Image Transformations)
- Full "Compare Plans" feature comparison across 8 categories with a sticky plan header
- FAQ accordion (native `<details>`, no client JS)
- CTA footer with a "not affiliated with Supabase" disclaimer

### Structure
- `src/app/supabase-clone/pricing-data.ts` — all pricing/feature data
- `src/app/supabase-clone/page.tsx` — server component, Tailwind only, no new dependencies

### Verification
- `eslint` and `next build` pass; route prerenders as static
- Reviewed full-page renders via headless Chrome at desktop (1440px) and mobile (390px) widths

[Desktop top section](https://cursor.com/agents/bc-dd8deba9-da08-4e18-a12f-95b330071a6e/artifacts?path=%2Ftmp%2Freview%2Ftop.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd8deba9-da08-4e18-a12f-95b330071a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd8deba9-da08-4e18-a12f-95b330071a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

