### PR TITLE
Arrakis: The Crossing — browser-playable 3D Dune sandwalking game at /dune

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "shawnesquivel.com",
       "version": "0.1.0",
       "dependencies": {
+        "@types/three": "^0.184.1",
         "@vercel/analytics": "^1.6.1",
         "gray-matter": "^4.0.3",
         "marked": "^17.0.3",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -278,6 +280,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -1516,6 +1524,12 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1577,6 +1591,32 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.55.0",
@@ -3571,6 +3611,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4996,6 +5042,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6199,6 +6251,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -3697,6 +3698,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5469,6 +5485,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "sanitize:hackathon-data": "node sanitize-hackathon-data.mjs"
   },
   "dependencies": {
+    "@types/three": "^0.184.1",
     "@vercel/analytics": "^1.6.1",
     "gray-matter": "^4.0.3",
     "marked": "^17.0.3",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/scripts/playtest-dune.mjs
+++ b/scripts/playtest-dune.mjs
@@ -1,0 +1,188 @@
+// End-to-end playthrough of /dune with Playwright.
+// Scenarios:
+//   1. intro renders, game starts
+//   2. sandwalking (irregular taps) keeps vibration low, label = "sandwalk"
+//   3. rhythmic walking (holding W) summons wormsign
+//   4. worm reaches the rhythmic walker -> breach -> death screen
+//   5. restart works
+//   6. thumper diverts an approaching worm, worm devours it and leaves
+//   7. drum sand instantly maxes vibration
+//   8. refuge rock = safe; worm balks and circles
+//   9. crossing to the sietch cliffs -> win screen + stats
+//
+// Usage: node scripts/playtest-dune.mjs [baseURL]
+
+import { chromium } from "playwright";
+import fs from "node:fs";
+
+const BASE = process.argv[2] ?? "http://localhost:3000";
+const SHOT_DIR = process.env.SHOT_DIR ?? "/tmp/dune-shots";
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+let failures = 0;
+function check(name, cond, extra = "") {
+  if (cond) console.log(`  PASS  ${name}`);
+  else {
+    failures++;
+    console.log(`  FAIL  ${name} ${extra}`);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await chromium.launch({
+  args: ["--enable-unsafe-swiftshader", "--use-gl=angle", "--use-angle=swiftshader"],
+});
+const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+page.on("pageerror", (e) => {
+  failures++;
+  console.log("  FAIL  page error:", e.message);
+});
+
+const state = () => page.evaluate(() => window.__DUNE__.getState());
+const shot = (name) => page.screenshot({ path: `${SHOT_DIR}/${name}.png` });
+
+console.log("\n=== 1. Load & intro ===");
+await page.goto(`${BASE}/dune`, { waitUntil: "networkidle" });
+await page.waitForFunction(() => window.__DUNE__ !== undefined, null, { timeout: 20000 });
+await sleep(2500); // let the intro fly-over settle
+check("intro phase", (await state()).phase === "intro");
+check("title visible", await page.getByRole("heading", { name: "THE CROSSING" }).isVisible());
+await shot("01-intro");
+
+console.log("\n=== 2. Start + sandwalk (irregular taps) ===");
+await page.getByTestId("start-button").click();
+await sleep(500);
+check("playing phase", (await state()).phase === "playing");
+await shot("02-start");
+
+// step off the rock first so steps register as sand steps
+await page.evaluate(() => window.__DUNE__.teleport(0, 215));
+// the book's broken pattern: step... drag... drag... step... step... wait...
+const brokenPattern = [180, 560, 210, 690, 340, 1150, 160, 420, 950, 260, 580, 200, 760, 330, 1100, 170];
+for (const gap of brokenPattern) {
+  await page.keyboard.press("KeyW", { delay: 40 });
+  await sleep(gap);
+}
+let s = await state();
+check("vibration stays low while sandwalking", s.vibration < 0.45, `vib=${s.vibration.toFixed(2)}`);
+check("no worm called", s.worm.state === "idle", `worm=${s.worm.state}`);
+check("sandwalk steps counted", s.sandwalkSteps >= 6, `sw=${s.sandwalkSteps}/${s.steps}`);
+await shot("03-sandwalking");
+
+console.log("\n=== 3. Rhythmic walking summons the worm ===");
+await page.keyboard.down("KeyW");
+await page.waitForFunction(() => window.__DUNE__.getState().worm.state !== "idle", null, { timeout: 25000 });
+s = await state();
+check("wormsign appears from rhythmic walking", s.worm.state === "approach", `worm=${s.worm.state}`);
+await page.getByTestId("wormsign").waitFor({ state: "visible", timeout: 5000 });
+check("wormsign HUD visible", await page.getByTestId("wormsign").isVisible());
+await shot("04-wormsign");
+
+console.log("\n=== 4. The worm takes the rhythmic walker ===");
+await page.waitForFunction(() => window.__DUNE__.getState().phase === "dead", null, { timeout: 90000 });
+await page.keyboard.up("KeyW");
+await page.getByTestId("death-screen").waitFor({ state: "visible", timeout: 5000 });
+check("death screen", await page.getByTestId("death-screen").isVisible());
+check("death quote", await page.getByText("approach of a mountain").isVisible());
+await shot("05-death");
+
+console.log("\n=== 5. Restart ===");
+await page.getByTestId("restart-button").click();
+await sleep(400);
+s = await state();
+check("restart -> playing", s.phase === "playing");
+check("worm reset", s.worm.state === "idle");
+check("position reset", Math.abs(s.z - 250) < 2, `z=${s.z.toFixed(1)}`);
+
+console.log("\n=== 6. Thumper diverts the worm ===");
+await page.evaluate(() => window.__DUNE__.teleport(0, 150));
+await page.evaluate(() => window.__DUNE__.setVibration(0.5));
+// summon via loud rhythmic steps
+await page.keyboard.down("KeyW");
+await page.waitForFunction(() => window.__DUNE__.getState().worm.state === "approach", null, { timeout: 25000 });
+await page.keyboard.up("KeyW");
+// plant a thumper, then slip away quietly
+await page.keyboard.press("KeyT");
+await sleep(300);
+s = await state();
+check("thumper planted", s.activeThumpers === 1 && s.thumpers === 1, `inv=${s.thumpers} active=${s.activeThumpers}`);
+await page.evaluate(() => window.__DUNE__.teleport(-68, 138)); // refuge rock, 70m+ away
+await page.waitForFunction(
+  () => {
+    const st = window.__DUNE__.getState();
+    return st.activeThumpers === 0 && st.phase === "playing";
+  },
+  null,
+  { timeout: 60000 }
+);
+s = await state();
+check("worm devoured the thumper, player alive", s.phase === "playing");
+await shot("06-thumper-devoured");
+// after finishing the breach the worm should depart sated
+await page.waitForFunction(
+  () => ["leave", "idle"].includes(window.__DUNE__.getState().worm.state),
+  null,
+  { timeout: 30000 }
+);
+s = await state();
+check("worm sated/leaving", ["leave", "idle"].includes(s.worm.state), `worm=${s.worm.state}`);
+check("player still alive after diversion", s.phase === "playing");
+
+console.log("\n=== 7. Drum sand ===");
+await page.evaluate(() => window.__DUNE__.restart());
+await sleep(300);
+await page.evaluate(() => window.__DUNE__.teleport(-14, 190)); // center of a drum patch
+await page.keyboard.press("KeyW");
+await sleep(400);
+s = await state();
+check("drum sand maxes vibration", s.vibration > 0.95, `vib=${s.vibration.toFixed(2)}`);
+check("drum sand summons worm", s.worm.state === "approach", `worm=${s.worm.state}`);
+check("drum sand message", (s.message ?? "").includes("DRUM SAND"));
+await shot("07-drum-sand");
+
+console.log("\n=== 8. Rock refuge is safe ===");
+await page.evaluate(() => window.__DUNE__.teleport(-68, 138)); // refuge
+await page.evaluate(() => window.__DUNE__.setVibration(1));
+// worm is inbound to our last loud position; wait for it to arrive & balk
+await page.waitForFunction(
+  () => {
+    const st = window.__DUNE__.getState();
+    return st.worm.state === "search" || st.worm.state === "leave" || st.worm.state === "idle";
+  },
+  null,
+  { timeout: 60000 }
+);
+s = await state();
+check("player alive on rock", s.phase === "playing");
+check("onRock flag", s.onRock === true);
+await shot("08-rock-refuge");
+
+console.log("\n=== 9. Reach the sietch -> victory ===");
+await page.evaluate(() => window.__DUNE__.restart());
+await sleep(300);
+await page.evaluate(() => window.__DUNE__.teleport(0, -225));
+// sandwalk the final stretch for real
+for (let i = 0; i < 30; i++) {
+  await page.keyboard.press("KeyW", { delay: 40 });
+  await sleep(120 + Math.random() * 500);
+  const st = await state();
+  if (st.phase === "won") break;
+}
+s = await state();
+check("victory", s.phase === "won", `phase=${s.phase} z=${s.z.toFixed(1)}`);
+await page.getByTestId("win-screen").waitFor({ state: "visible", timeout: 5000 });
+check("win screen", await page.getByTestId("win-screen").isVisible());
+check("win stats steps > 0", s.steps > 0);
+await shot("09-victory");
+
+console.log("\n=== 10. Visual sanity: canvas actually renders ===");
+// A black/blank 1280x720 frame compresses to a few KB; a rendered desert is far larger.
+for (const f of ["02-start", "04-wormsign", "07-drum-sand"]) {
+  const size = fs.statSync(`${SHOT_DIR}/${f}.png`).size;
+  check(`screenshot ${f} is a real render`, size > 60000, `${size} bytes`);
+}
+
+await browser.close();
+console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} FAILURES`}\nScreenshots: ${SHOT_DIR}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/dune/page.tsx
+++ b/src/app/dune/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import DuneGame from "@/components/dune/DuneGame";
+
+export const metadata: Metadata = {
+  title: "Arrakis: The Crossing — a Dune sandwalking game",
+  description:
+    "Cross the open desert of Arrakis in your browser. Walk without rhythm, avoid drum sand, plant thumpers — or Shai-Hulud will find you.",
+};
+
+export default function DunePage() {
+  return <DuneGame />;
+}

--- a/src/components/dune/DuneGame.tsx
+++ b/src/components/dune/DuneGame.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { DuneGame as Engine, HudState } from "@/lib/dune/game";
+
+const INITIAL_HUD: HudState = {
+  phase: "intro",
+  vibration: 0,
+  stepLabel: null,
+  wormState: "idle",
+  wormDistance: null,
+  distanceToGoal: 0,
+  thumpers: 2,
+  onRock: true,
+  onSpice: false,
+  message: null,
+  messageTone: "info",
+  stats: { time: 0, steps: 0, sandwalkSteps: 0, wormsCalled: 0, thumpersUsed: 0 },
+};
+
+function formatTime(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+export default function DuneGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<Engine | null>(null);
+  const [hud, setHud] = useState<HudState>(INITIAL_HUD);
+  const frameSkip = useRef(0);
+
+  useEffect(() => {
+    let disposed = false;
+    let engine: Engine | null = null;
+    void import("@/lib/dune/game").then(({ DuneGame: GameEngine }) => {
+      if (disposed || !canvasRef.current) return;
+      engine = new GameEngine(canvasRef.current, (h) => {
+        // throttle React updates to ~20fps; the canvas runs at full speed
+        frameSkip.current = (frameSkip.current + 1) % 3;
+        if (frameSkip.current === 0) setHud({ ...h });
+      });
+      engineRef.current = engine;
+    });
+    return () => {
+      disposed = true;
+      engine?.dispose();
+      engineRef.current = null;
+    };
+  }, []);
+
+  const vibPct = Math.round(hud.vibration * 100);
+  const vibColor =
+    hud.vibration < 0.35 ? "#7fb069" : hud.vibration < 0.55 ? "#e8a33d" : "#d64933";
+  const wormNear = hud.wormDistance !== null && hud.wormDistance < 150;
+
+  return (
+    <div className="relative h-dvh w-full overflow-hidden bg-black font-sans select-none">
+      <canvas ref={canvasRef} className="block h-full w-full" />
+
+      {/* ---------- in-game HUD ---------- */}
+      {hud.phase === "playing" && (
+        <>
+          {/* vibration meter */}
+          <div className="pointer-events-none absolute bottom-6 left-1/2 w-[min(420px,80vw)] -translate-x-1/2">
+            <div className="mb-1 flex items-end justify-between text-[11px] tracking-[0.2em] text-amber-100/80 uppercase">
+              <span>Vibration</span>
+              {hud.stepLabel && (
+                <span
+                  data-testid="step-label"
+                  className={
+                    hud.stepLabel === "sandwalk"
+                      ? "text-lime-300"
+                      : hud.stepLabel === "uneven"
+                        ? "text-amber-300"
+                        : "animate-pulse text-red-400"
+                  }
+                >
+                  {hud.stepLabel === "sandwalk"
+                    ? "sandwalk — like the wind"
+                    : hud.stepLabel === "uneven"
+                      ? "uneven"
+                      : "RHYTHMIC — it hears you"}
+                </span>
+              )}
+            </div>
+            <div className="h-2.5 overflow-hidden rounded-full border border-amber-100/20 bg-black/45 backdrop-blur-sm">
+              <div
+                data-testid="vibration-bar"
+                className="h-full rounded-full transition-[width] duration-150"
+                style={{ width: `${vibPct}%`, background: vibColor }}
+              />
+            </div>
+          </div>
+
+          {/* top-left status */}
+          <div className="pointer-events-none absolute top-4 left-4 space-y-1 text-[12px] text-amber-50/90">
+            <div className="rounded bg-black/40 px-3 py-1.5 backdrop-blur-sm">
+              <span className="tracking-[0.18em] text-amber-200/70 uppercase">Sietch&nbsp;</span>
+              <span data-testid="distance" className="font-semibold tabular-nums">
+                {Math.round(hud.distanceToGoal)}m
+              </span>
+            </div>
+            <div className="rounded bg-black/40 px-3 py-1.5 backdrop-blur-sm">
+              <span className="tracking-[0.18em] text-amber-200/70 uppercase">Thumpers&nbsp;</span>
+              <span className="font-semibold">{"▮".repeat(hud.thumpers) || "—"}</span>
+            </div>
+            {hud.onRock && (
+              <div className="rounded bg-emerald-900/50 px-3 py-1.5 text-emerald-200 backdrop-blur-sm">
+                On rock — safe from the worm
+              </div>
+            )}
+          </div>
+
+          {/* wormsign warning */}
+          {hud.wormState !== "idle" && (
+            <div
+              data-testid="wormsign"
+              className={`pointer-events-none absolute top-4 left-1/2 -translate-x-1/2 rounded px-4 py-2 text-center backdrop-blur-sm ${
+                wormNear ? "animate-pulse bg-red-950/70 text-red-200" : "bg-orange-950/60 text-orange-200"
+              }`}
+            >
+              <div className="text-[11px] tracking-[0.3em] uppercase">
+                {hud.wormState === "breach" ? "Shai-Hulud" : "Wormsign"}
+              </div>
+              {hud.wormDistance !== null && hud.wormState !== "breach" && (
+                <div className="text-sm font-semibold tabular-nums">
+                  {Math.round(hud.wormDistance)}m {hud.wormState === "leave" ? "— departing" : hud.wormState === "search" ? "— circling" : "— approaching"}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* contextual message */}
+          {hud.message && (
+            <div
+              data-testid="message"
+              className={`pointer-events-none absolute bottom-20 left-1/2 w-[min(560px,86vw)] -translate-x-1/2 rounded px-4 py-2 text-center text-[13px] leading-snug backdrop-blur-sm ${
+                hud.messageTone === "danger"
+                  ? "bg-red-950/65 text-red-100"
+                  : hud.messageTone === "good"
+                    ? "bg-emerald-950/60 text-emerald-100"
+                    : "bg-black/50 text-amber-50"
+              }`}
+            >
+              {hud.message}
+            </div>
+          )}
+
+          {/* controls hint */}
+          <div className="pointer-events-none absolute right-4 bottom-4 hidden rounded bg-black/35 px-3 py-2 text-right text-[10px] leading-relaxed text-amber-100/50 backdrop-blur-sm sm:block">
+            tap W/A/S/D — irregular single steps (sandwalk)
+            <br />
+            hold W — steady walk (loud) · Shift — run (very loud)
+            <br />
+            mouse / Q E — look · T — plant thumper
+          </div>
+        </>
+      )}
+
+      {/* ---------- intro ---------- */}
+      {hud.phase === "intro" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-black/70 via-black/40 to-black/75 p-6">
+          <div className="max-w-xl text-center text-amber-50">
+            <div className="text-[11px] tracking-[0.5em] text-amber-300/70 uppercase">Arrakis · Dune · Desert Planet</div>
+            <h1 className="mt-2 font-serif text-5xl font-bold tracking-wide text-amber-100 sm:text-6xl">
+              THE CROSSING
+            </h1>
+            <p className="mx-auto mt-5 max-w-md text-sm leading-relaxed text-amber-100/85">
+              Your ornithopter is down. The sietch cliffs lie across open erg —
+              worm territory. The sand carries every footfall to Shai-Hulud.
+            </p>
+            <blockquote className="mx-auto mt-4 max-w-md border-l-2 border-amber-400/40 pl-3 text-left text-[13px] text-amber-200/75 italic">
+              “We must walk without rhythm… they must sound like the natural
+              shifting of sand… like the wind. Step… drag… drag… step… step…
+              wait… drag… step…”
+            </blockquote>
+            <div className="mx-auto mt-5 grid max-w-md grid-cols-1 gap-1.5 text-left text-[12px] text-amber-100/70 sm:grid-cols-2">
+              <div><b className="text-lime-300">Tap</b> W/A/S/D — single steps. Break your timing.</div>
+              <div><b className="text-red-300">Hold</b> W or Shift — fast but rhythmic. It will hear.</div>
+              <div><b className="text-amber-200">T</b> — plant a thumper to lure the worm away.</div>
+              <div><b className="text-emerald-300">Rock</b> is safe. Pale taut sand is drum sand — never step on it.</div>
+            </div>
+            <button
+              data-testid="start-button"
+              onClick={() => engineRef.current?.start()}
+              className="mt-7 cursor-pointer rounded border border-amber-300/50 bg-amber-400/10 px-10 py-3 text-sm font-semibold tracking-[0.3em] text-amber-100 uppercase transition hover:bg-amber-400/25"
+            >
+              Begin the crossing
+            </button>
+            <div className="mt-3 text-[11px] text-amber-100/40">click the sand to lock the mouse · headphones recommended</div>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- death ---------- */}
+      {hud.phase === "dead" && (
+        <div data-testid="death-screen" className="absolute inset-0 flex items-center justify-center bg-red-950/60 p-6 backdrop-blur-[2px]">
+          <div className="max-w-lg text-center text-amber-50">
+            <h2 className="font-serif text-4xl font-bold text-red-200">TAKEN BY SHAI-HULUD</h2>
+            <blockquote className="mx-auto mt-4 max-w-md text-[13px] text-amber-100/80 italic">
+              “It appeared to be more than half a league long, and the rise of the
+              sandwave at its cresting head was like the approach of a mountain.”
+            </blockquote>
+            <p className="mt-3 text-[13px] text-amber-200/70">
+              Bless the Maker and His water. May His passage cleanse the world.
+            </p>
+            <StatsBlock hud={hud} />
+            <button
+              data-testid="restart-button"
+              onClick={() => engineRef.current?.restart()}
+              className="mt-6 cursor-pointer rounded border border-amber-300/50 bg-amber-400/10 px-8 py-3 text-sm font-semibold tracking-[0.3em] text-amber-100 uppercase transition hover:bg-amber-400/25"
+            >
+              Walk again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- victory ---------- */}
+      {hud.phase === "won" && (
+        <div data-testid="win-screen" className="absolute inset-0 flex items-center justify-center bg-emerald-950/50 p-6 backdrop-blur-[2px]">
+          <div className="max-w-lg text-center text-amber-50">
+            <h2 className="font-serif text-4xl font-bold text-emerald-200">YOU REACHED THE SIETCH</h2>
+            <p className="mt-4 text-sm text-amber-100/85">
+              You crossed the open erg and the worm did not take you. You walked
+              as the Fremen walk — without rhythm, like the shifting of sand.
+            </p>
+            <blockquote className="mt-3 text-[13px] text-amber-200/70 italic">
+              “God created Arrakis to train the faithful.”
+            </blockquote>
+            <StatsBlock hud={hud} />
+            <button
+              data-testid="restart-button"
+              onClick={() => engineRef.current?.restart()}
+              className="mt-6 cursor-pointer rounded border border-emerald-300/50 bg-emerald-400/10 px-8 py-3 text-sm font-semibold tracking-[0.3em] text-emerald-100 uppercase transition hover:bg-emerald-400/25"
+            >
+              Cross again
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatsBlock({ hud }: { hud: HudState }) {
+  const s = hud.stats;
+  const pct = s.steps > 0 ? Math.round((s.sandwalkSteps / s.steps) * 100) : 0;
+  return (
+    <div className="mx-auto mt-5 grid max-w-sm grid-cols-2 gap-x-6 gap-y-1.5 rounded bg-black/40 px-5 py-4 text-left text-[12px] text-amber-100/80">
+      <span>Time</span>
+      <span className="text-right font-semibold tabular-nums">{formatTime(s.time)}</span>
+      <span>Steps taken</span>
+      <span className="text-right font-semibold tabular-nums">{s.steps}</span>
+      <span>Sandwalk steps</span>
+      <span className="text-right font-semibold tabular-nums">{s.sandwalkSteps} ({pct}%)</span>
+      <span>Worms drawn</span>
+      <span className="text-right font-semibold tabular-nums">{s.wormsCalled}</span>
+      <span>Thumpers used</span>
+      <span className="text-right font-semibold tabular-nums">{s.thumpersUsed}</span>
+    </div>
+  );
+}

--- a/src/components/dune/DuneGame.tsx
+++ b/src/components/dune/DuneGame.tsx
@@ -189,6 +189,9 @@ export default function DuneGame() {
               Begin the crossing
             </button>
             <div className="mt-3 text-[11px] text-amber-100/40">click the sand to lock the mouse · headphones recommended</div>
+            <div className="mt-2 hidden text-[11px] text-red-300/70 [@media(hover:none)]:block">
+              This crossing requires a keyboard — visit on a desktop browser.
+            </div>
           </div>
         </div>
       )}

--- a/src/lib/dune/audio.ts
+++ b/src/lib/dune/audio.ts
@@ -1,0 +1,201 @@
+// Fully procedural WebAudio soundscape: desert wind, footfalls on sand,
+// drum-sand booms, the thumper's "lump... lump", and the rising rumble and
+// sand-hiss of an approaching Shai-Hulud.
+
+import { clamp } from "./noise";
+
+export class DuneAudio {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private noiseBuf: AudioBuffer | null = null;
+
+  // continuous layers
+  private windGain: GainNode | null = null;
+  private windFilter: BiquadFilterNode | null = null;
+  private rumbleGain: GainNode | null = null;
+  private hissGain: GainNode | null = null;
+  private heartTimer = 0;
+  private thumperTimer = 0;
+
+  get ready(): boolean {
+    return this.ctx !== null;
+  }
+
+  init(): void {
+    if (this.ctx) {
+      if (this.ctx.state === "suspended") void this.ctx.resume();
+      return;
+    }
+    const Ctx = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    this.ctx = ctx;
+    this.master = ctx.createGain();
+    this.master.gain.value = 0.85;
+    this.master.connect(ctx.destination);
+
+    // shared noise source buffer (2s of white noise)
+    const buf = ctx.createBuffer(1, ctx.sampleRate * 2, ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+    this.noiseBuf = buf;
+
+    // --- wind: looped noise through a wandering bandpass
+    const wind = ctx.createBufferSource();
+    wind.buffer = buf;
+    wind.loop = true;
+    const wf = ctx.createBiquadFilter();
+    wf.type = "bandpass";
+    wf.frequency.value = 480;
+    wf.Q.value = 0.6;
+    const wg = ctx.createGain();
+    wg.gain.value = 0.05;
+    wind.connect(wf).connect(wg).connect(this.master);
+    wind.start();
+    this.windGain = wg;
+    this.windFilter = wf;
+
+    // --- worm rumble: looped noise through a deep lowpass
+    const rum = ctx.createBufferSource();
+    rum.buffer = buf;
+    rum.loop = true;
+    rum.playbackRate.value = 0.3;
+    const rf = ctx.createBiquadFilter();
+    rf.type = "lowpass";
+    rf.frequency.value = 70;
+    const rg = ctx.createGain();
+    rg.gain.value = 0;
+    rum.connect(rf).connect(rg).connect(this.master);
+    rum.start();
+    this.rumbleGain = rg;
+
+    // --- sand hiss of the moving mound
+    const hiss = ctx.createBufferSource();
+    hiss.buffer = buf;
+    hiss.loop = true;
+    const hf = ctx.createBiquadFilter();
+    hf.type = "highpass";
+    hf.frequency.value = 3200;
+    const hg = ctx.createGain();
+    hg.gain.value = 0;
+    hiss.connect(hf).connect(hg).connect(this.master);
+    hiss.start();
+    this.hissGain = hg;
+  }
+
+  /** Per-frame ambience update. wormDist = Infinity when no worm. */
+  update(dt: number, t: number, wormDist: number, wormActive: boolean, thumperDist: number | null): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.windGain || !this.windFilter) return;
+    // gusting wind
+    const gust = 0.045 + 0.035 * (0.5 + 0.5 * Math.sin(t * 0.31) * Math.sin(t * 0.137 + 2));
+    this.windGain.gain.setTargetAtTime(gust, ctx.currentTime, 0.4);
+    this.windFilter.frequency.setTargetAtTime(380 + 240 * Math.sin(t * 0.21), ctx.currentTime, 0.5);
+
+    // worm proximity layers
+    const prox = wormActive ? clamp(1 - wormDist / 480, 0, 1) : 0;
+    this.rumbleGain?.gain.setTargetAtTime(prox * prox * 0.65, ctx.currentTime, 0.25);
+    this.hissGain?.gain.setTargetAtTime(prox > 0.12 ? prox * 0.09 : 0, ctx.currentTime, 0.3);
+
+    // heartbeat under extreme danger
+    if (wormActive && wormDist < 90) {
+      this.heartTimer -= dt;
+      if (this.heartTimer <= 0) {
+        this.heartTimer = clamp(wormDist / 90, 0.35, 1) * 0.9;
+        this.thump(48, 0.16, 0.09);
+        setTimeout(() => this.thump(44, 0.12, 0.07), 180);
+      }
+    }
+
+    // thumper drumming, attenuated by distance
+    if (thumperDist !== null) {
+      this.thumperTimer -= dt;
+      if (this.thumperTimer <= 0) {
+        this.thumperTimer = 0.72;
+        const vol = clamp(1 - thumperDist / 320, 0.05, 1) * 0.5;
+        this.thump(72, 0.3, vol);
+      }
+    }
+  }
+
+  private thump(freq: number, dur: number, vol: number): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.master) return;
+    const o = ctx.createOscillator();
+    o.type = "sine";
+    o.frequency.setValueAtTime(freq, ctx.currentTime);
+    o.frequency.exponentialRampToValueAtTime(Math.max(20, freq * 0.45), ctx.currentTime + dur);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(vol, ctx.currentTime);
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
+    o.connect(g).connect(this.master);
+    o.start();
+    o.stop(ctx.currentTime + dur + 0.05);
+  }
+
+  private noiseBurst(dur: number, vol: number, filterFreq: number, type: BiquadFilterType = "lowpass"): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.master || !this.noiseBuf) return;
+    const src = ctx.createBufferSource();
+    src.buffer = this.noiseBuf;
+    src.playbackRate.value = 0.7 + Math.random() * 0.5;
+    const f = ctx.createBiquadFilter();
+    f.type = type;
+    f.frequency.value = filterFreq;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(vol, ctx.currentTime);
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
+    src.connect(f).connect(g).connect(this.master);
+    src.start(ctx.currentTime, Math.random() * 1.2, dur + 0.05);
+  }
+
+  footstep(kind: "step" | "walk" | "run" | "drag"): void {
+    if (!this.ctx) return;
+    if (kind === "drag") this.noiseBurst(0.22, 0.07, 900);
+    else if (kind === "run") this.noiseBurst(0.1, 0.16, 1400);
+    else this.noiseBurst(0.12, 0.1, 1100);
+  }
+
+  drumBoom(): void {
+    this.thump(55, 0.9, 0.9);
+    this.noiseBurst(0.7, 0.3, 240);
+    setTimeout(() => this.thump(42, 0.8, 0.5), 240);
+  }
+
+  wormBreach(): void {
+    this.thump(38, 1.4, 1.0);
+    this.noiseBurst(1.4, 0.5, 500);
+    this.noiseBurst(1.0, 0.25, 4000, "highpass");
+  }
+
+  plantThumper(): void {
+    this.noiseBurst(0.18, 0.2, 800);
+  }
+
+  win(): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.master) return;
+    [220, 277, 330, 440].forEach((f, i) => {
+      const o = ctx.createOscillator();
+      o.type = "sine";
+      o.frequency.value = f;
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.0001, ctx.currentTime + i * 0.18);
+      g.gain.exponentialRampToValueAtTime(0.12, ctx.currentTime + i * 0.18 + 0.06);
+      g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + i * 0.18 + 1.6);
+      o.connect(g).connect(this.master!);
+      o.start(ctx.currentTime + i * 0.18);
+      o.stop(ctx.currentTime + i * 0.18 + 1.8);
+    });
+  }
+
+  death(): void {
+    this.wormBreach();
+    setTimeout(() => this.thump(30, 2.0, 0.9), 300);
+  }
+
+  dispose(): void {
+    void this.ctx?.close();
+    this.ctx = null;
+  }
+}

--- a/src/lib/dune/dot-texture.ts
+++ b/src/lib/dune/dot-texture.ts
@@ -1,0 +1,15 @@
+import * as THREE from "three";
+
+/** Soft round dot texture so point particles don't render as hard squares. */
+export function makeDotTexture(): THREE.CanvasTexture {
+  const c = document.createElement("canvas");
+  c.width = c.height = 32;
+  const g = c.getContext("2d")!;
+  const grad = g.createRadialGradient(16, 16, 1, 16, 16, 15);
+  grad.addColorStop(0, "rgba(255,255,255,1)");
+  grad.addColorStop(0.5, "rgba(255,255,255,0.45)");
+  grad.addColorStop(1, "rgba(255,255,255,0)");
+  g.fillStyle = grad;
+  g.fillRect(0, 0, 32, 32);
+  return new THREE.CanvasTexture(c);
+}

--- a/src/lib/dune/game.ts
+++ b/src/lib/dune/game.ts
@@ -1,0 +1,892 @@
+// Arrakis Crossing — main engine. Owns the three.js scene, the player
+// (sandwalk mechanics), the worm, thumpers, ambience and the HUD feed.
+
+import * as THREE from "three";
+import {
+  WORLD_SIZE,
+  START,
+  GOAL_Z,
+  CLIFF_Z,
+  BOUND,
+  terrainHeight,
+  isOnRock,
+  isOnDrumSand,
+  isOnSpice,
+  drumFactor,
+  spiceFactor,
+  rockFactor,
+  REFUGES,
+  SPICE_PATCHES,
+} from "./world";
+import { fbm2, clamp, lerp } from "./noise";
+import { RhythmTracker, StepKind } from "./rhythm";
+import { SandWorm, WormState, WORM_KILL_RADIUS } from "./worm";
+import { DuneAudio } from "./audio";
+
+export type Phase = "intro" | "playing" | "dead" | "won";
+
+export interface HudState {
+  phase: Phase;
+  vibration: number;
+  stepLabel: "sandwalk" | "uneven" | "rhythmic" | null;
+  wormState: WormState;
+  wormDistance: number | null;
+  distanceToGoal: number;
+  thumpers: number;
+  onRock: boolean;
+  onSpice: boolean;
+  message: string | null;
+  messageTone: "info" | "danger" | "good";
+  stats: {
+    time: number;
+    steps: number;
+    sandwalkSteps: number;
+    wormsCalled: number;
+    thumpersUsed: number;
+  };
+}
+
+interface Thumper {
+  id: number;
+  x: number;
+  z: number;
+  mesh: THREE.Group;
+  clapper: THREE.Mesh;
+  ttl: number;
+  tick: number;
+}
+
+const PLAYER_EYE = 1.7;
+const FRICTION = 5.5;
+const VIBRATION_TRIGGER = 0.55;
+
+export class DuneGame {
+  private renderer: THREE.WebGLRenderer;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private clock = new THREE.Clock();
+  private elapsed = 0;
+  private raf = 0;
+  private disposed = false;
+
+  // player
+  private pos = new THREE.Vector3(START.x, 0, START.z);
+  private vel = new THREE.Vector3();
+  private yaw = Math.PI; // facing -z (toward the sietch)
+  private pitch = 0;
+  private keys = new Set<string>();
+  private moveHeldTime = 0;
+  private autoStepTimer = 0;
+  private bob = 0;
+  private bobPhase = 0;
+  private shake = 0;
+  private rhythm = new RhythmTracker();
+  private vibration = 0;
+  private stepLabelTtl = 0;
+
+  // entities
+  private worm: SandWorm;
+  private thumpers: Thumper[] = [];
+  private thumperInventory = 2;
+  private nextThumperId = 1;
+
+  // ambience
+  private audio = new DuneAudio();
+  private windPoints!: THREE.Points;
+  private windData!: Float32Array;
+  private spicePoints!: THREE.Points;
+  private skyMat!: THREE.ShaderMaterial;
+
+  // state
+  phase: Phase = "intro";
+  private startTime = 0;
+  private steps = 0;
+  private sandwalkSteps = 0;
+  private thumpersUsed = 0;
+  private message: string | null = null;
+  private messageTone: "info" | "danger" | "good" = "info";
+  private messageTtl = 0;
+  private spiceNoticed = false;
+  private wormsignAnnounced = false;
+
+  hud: HudState;
+  onHud: (h: HudState) => void;
+
+  constructor(canvas: HTMLCanvasElement, onHud: (h: HudState) => void) {
+    this.onHud = onHud;
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 1.05;
+
+    this.scene = new THREE.Scene();
+    this.scene.fog = new THREE.FogExp2(0xcf9a64, 0.00115);
+
+    this.camera = new THREE.PerspectiveCamera(
+      72,
+      canvas.clientWidth / Math.max(1, canvas.clientHeight),
+      0.1,
+      5000
+    );
+
+    this.buildSky();
+    this.buildLights();
+    this.buildTerrain();
+    this.buildRocks();
+    this.buildSietchGlow();
+    this.buildWind();
+    this.buildSpiceGlitter();
+
+    this.worm = new SandWorm(this.scene);
+    this.worm.onBreachStart = (x, z, kind) => {
+      this.shake = Math.max(this.shake, kind === "player" ? 1.4 : 0.7);
+      this.audio.wormBreach();
+      if (kind === "player") {
+        this.showMessage("Shai-Hulud rises — a gaping round mouth, crystal teeth glinting!", "danger", 4);
+      } else {
+        this.showMessage("The Maker breaches and takes the thumper.", "info", 4);
+      }
+    };
+    this.worm.onBreachHit = (x, z, kind, thumperId) => {
+      if (kind === "thumper" && thumperId !== undefined) {
+        this.removeThumper(thumperId);
+      } else {
+        const d = Math.hypot(this.pos.x - x, this.pos.z - z);
+        if (d < WORM_KILL_RADIUS && !isOnRock(this.pos.x, this.pos.z)) {
+          this.die();
+        } else {
+          this.showMessage("The strike misses — sand rains down around you.", "danger", 3.5);
+          this.shake = Math.max(this.shake, 1.0);
+        }
+      }
+    };
+    this.worm.onDeparted = () => {
+      this.wormsignAnnounced = false;
+      this.showMessage("The drumming fades. The desert is still again.", "good", 4);
+    };
+
+    this.hud = this.makeHud();
+
+    window.addEventListener("keydown", this.onKeyDown);
+    window.addEventListener("keyup", this.onKeyUp);
+    window.addEventListener("resize", this.onResize);
+    canvas.addEventListener("click", this.onCanvasClick);
+    document.addEventListener("mousemove", this.onMouseMove);
+
+    this.installTestHooks();
+    this.loop();
+  }
+
+  // ---------------------------------------------------------------- scene
+
+  private buildSky(): void {
+    const geo = new THREE.SphereGeometry(2400, 32, 20);
+    this.skyMat = new THREE.ShaderMaterial({
+      side: THREE.BackSide,
+      depthWrite: false,
+      uniforms: {
+        topColor: { value: new THREE.Color(0x1a2240) },
+        midColor: { value: new THREE.Color(0x7a5a78) },
+        horizonColor: { value: new THREE.Color(0xeFa45c) },
+        sunDir: { value: new THREE.Vector3(0.55, 0.13, -0.82).normalize() },
+      },
+      vertexShader: `
+        varying vec3 vDir;
+        void main() {
+          vDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: `
+        uniform vec3 topColor; uniform vec3 midColor; uniform vec3 horizonColor; uniform vec3 sunDir;
+        varying vec3 vDir;
+        void main() {
+          float t = max(vDir.y, 0.0);
+          vec3 col = mix(horizonColor, midColor, smoothstep(0.0, 0.22, t));
+          col = mix(col, topColor, smoothstep(0.12, 0.65, t));
+          float s = max(dot(normalize(vDir), sunDir), 0.0);
+          col += vec3(1.0, 0.62, 0.3) * pow(s, 110.0) * 1.6;   // sun disc glow
+          col += vec3(1.0, 0.55, 0.25) * pow(s, 7.0) * 0.28;   // dawn haze
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+    });
+    this.scene.add(new THREE.Mesh(geo, this.skyMat));
+
+    // stars in the upper dome
+    const N = 1100;
+    const sp = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
+      const a = Math.random() * Math.PI * 2;
+      const y = 0.18 + Math.random() * 0.82;
+      const r = Math.sqrt(Math.max(0, 1 - y * y));
+      sp[i * 3] = Math.cos(a) * r * 2200;
+      sp[i * 3 + 1] = y * 2200;
+      sp[i * 3 + 2] = Math.sin(a) * r * 2200;
+    }
+    const sg = new THREE.BufferGeometry();
+    sg.setAttribute("position", new THREE.BufferAttribute(sp, 3));
+    const stars = new THREE.Points(
+      sg,
+      new THREE.PointsMaterial({ color: 0xdde6ff, size: 3.2, sizeAttenuation: false, transparent: true, opacity: 0.75, fog: false, depthWrite: false })
+    );
+    this.scene.add(stars);
+
+    // the two moons of Arrakis
+    const moonTex = (tint: string, dark: string) => {
+      const c = document.createElement("canvas");
+      c.width = c.height = 128;
+      const g = c.getContext("2d")!;
+      const grad = g.createRadialGradient(54, 50, 8, 64, 64, 62);
+      grad.addColorStop(0, tint);
+      grad.addColorStop(0.75, dark);
+      grad.addColorStop(1, "rgba(0,0,0,0)");
+      g.fillStyle = grad;
+      g.beginPath();
+      g.arc(64, 64, 62, 0, Math.PI * 2);
+      g.fill();
+      // mottling
+      g.globalAlpha = 0.18;
+      for (let i = 0; i < 26; i++) {
+        g.fillStyle = "#00000088";
+        g.beginPath();
+        g.arc(20 + Math.random() * 88, 20 + Math.random() * 88, 2 + Math.random() * 7, 0, Math.PI * 2);
+        g.fill();
+      }
+      const tx = new THREE.CanvasTexture(c);
+      return tx;
+    };
+    const m1 = new THREE.Sprite(new THREE.SpriteMaterial({ map: moonTex("#f5ead8", "#b9a98c"), fog: false, depthWrite: false }));
+    m1.scale.set(210, 210, 1);
+    m1.position.set(-900, 1150, -1500);
+    this.scene.add(m1);
+    const m2 = new THREE.Sprite(new THREE.SpriteMaterial({ map: moonTex("#cdd8ea", "#8b96ad"), fog: false, depthWrite: false }));
+    m2.scale.set(110, 110, 1);
+    m2.position.set(1100, 800, -1100);
+    this.scene.add(m2);
+  }
+
+  private buildLights(): void {
+    const sun = new THREE.DirectionalLight(0xffc890, 1.55);
+    sun.position.set(550, 190, -820);
+    this.scene.add(sun);
+    const hemi = new THREE.HemisphereLight(0x9db4d8, 0xc69058, 0.62);
+    this.scene.add(hemi);
+  }
+
+  private buildTerrain(): void {
+    const SEG = 300;
+    const geo = new THREE.PlaneGeometry(WORLD_SIZE, WORLD_SIZE, SEG, SEG);
+    geo.rotateX(-Math.PI / 2);
+    const posAttr = geo.attributes.position as THREE.BufferAttribute;
+    const colors = new Float32Array(posAttr.count * 3);
+    const cBase = new THREE.Color();
+    for (let i = 0; i < posAttr.count; i++) {
+      const x = posAttr.getX(i);
+      const z = posAttr.getZ(i);
+      const h = terrainHeight(x, z);
+      posAttr.setY(i, h);
+
+      // base sand with subtle hue variation + crest lightening
+      const v = fbm2(x * 0.02 + 31, z * 0.02 - 17, 3) * 0.5 + 0.5;
+      cBase.setRGB(
+        lerp(0.78, 0.88, v),
+        lerp(0.55, 0.65, v),
+        lerp(0.34, 0.42, v)
+      );
+      const crest = clamp((h - 6) / 8, 0, 1);
+      cBase.lerp(new THREE.Color(0.95, 0.78, 0.55), crest * 0.35);
+
+      // drum sand: paler, smoother, slightly grey — visibly taut
+      const df = drumFactor(x, z);
+      if (df > 0) cBase.lerp(new THREE.Color(0.93, 0.88, 0.72), df * 0.85);
+
+      // spice: rust-cinnamon stain
+      const sf = spiceFactor(x, z);
+      if (sf > 0) cBase.lerp(new THREE.Color(0.62, 0.28, 0.1), sf * 0.7);
+
+      // rock pads + cliff: dark basalt
+      const rf = rockFactor(x, z);
+      const cliffF = clamp((CLIFF_Z - z) / 60, 0, 1);
+      const rocky = Math.max(rf, cliffF);
+      if (rocky > 0) cBase.lerp(new THREE.Color(0.27, 0.23, 0.2), rocky * 0.92);
+
+      colors[i * 3] = cBase.r;
+      colors[i * 3 + 1] = cBase.g;
+      colors[i * 3 + 2] = cBase.b;
+    }
+    geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+    geo.computeVertexNormals();
+    const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 1, metalness: 0 });
+    this.scene.add(new THREE.Mesh(geo, mat));
+  }
+
+  private buildRocks(): void {
+    const rockMat = new THREE.MeshStandardMaterial({ color: 0x453a31, roughness: 0.95, flatShading: true });
+    const addBoulders = (cx: number, cz: number, r: number, count: number) => {
+      for (let i = 0; i < count; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const rr = r * (0.45 + Math.random() * 0.65);
+        const x = cx + Math.cos(a) * rr;
+        const z = cz + Math.sin(a) * rr;
+        const s = 0.8 + Math.random() * 2.6;
+        const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(s, 0), rockMat);
+        rock.position.set(x, terrainHeight(x, z) + s * 0.25, z);
+        rock.rotation.set(Math.random() * 3, Math.random() * 3, Math.random() * 3);
+        rock.scale.y = 0.6 + Math.random() * 0.5;
+        this.scene.add(rock);
+      }
+    };
+    addBoulders(START.x, START.z, START.r, 14);
+    for (const rf of REFUGES) addBoulders(rf.x, rf.z, rf.r, 9);
+    // jagged crags along the cliff top
+    for (let i = 0; i < 40; i++) {
+      const x = -640 + Math.random() * 1280;
+      const z = CLIFF_Z - 70 - Math.random() * 90;
+      const s = 8 + Math.random() * 26;
+      const crag = new THREE.Mesh(new THREE.ConeGeometry(s * 0.7, s * 2.4, 5), rockMat);
+      crag.position.set(x, terrainHeight(x, z) + s * 0.6, z);
+      crag.rotation.y = Math.random() * 3;
+      this.scene.add(crag);
+    }
+  }
+
+  private buildSietchGlow(): void {
+    // warm cave-mouth lights in the cliff face — the way home
+    const glowMat = new THREE.MeshBasicMaterial({ color: 0xffb45e, fog: false });
+    const positions = [
+      { x: -16, y: 16 },
+      { x: 2, y: 11 },
+      { x: 20, y: 19 },
+    ];
+    for (const p of positions) {
+      const glow = new THREE.Mesh(new THREE.PlaneGeometry(4.5, 6.5), glowMat);
+      const z = CLIFF_Z - 26;
+      glow.position.set(p.x, terrainHeight(p.x, z) + p.y, z);
+      this.scene.add(glow);
+    }
+  }
+
+  private buildWind(): void {
+    const N = 800;
+    this.windData = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
+      this.windData[i * 3] = (Math.random() - 0.5) * 140;
+      this.windData[i * 3 + 1] = Math.random() * 26;
+      this.windData[i * 3 + 2] = (Math.random() - 0.5) * 140;
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(this.windData, 3));
+    this.windPoints = new THREE.Points(
+      geo,
+      new THREE.PointsMaterial({ color: 0xe2bb86, size: 0.45, transparent: true, opacity: 0.5, depthWrite: false })
+    );
+    this.scene.add(this.windPoints);
+  }
+
+  private buildSpiceGlitter(): void {
+    const pts: number[] = [];
+    for (const p of SPICE_PATCHES) {
+      for (let i = 0; i < 110; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const r = Math.sqrt(Math.random()) * p.r;
+        const x = p.x + Math.cos(a) * r;
+        const z = p.z + Math.sin(a) * r;
+        pts.push(x, terrainHeight(x, z) + 0.18 + Math.random() * 0.5, z);
+      }
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(pts), 3));
+    this.spicePoints = new THREE.Points(
+      geo,
+      new THREE.PointsMaterial({ color: 0xff9a3c, size: 0.35, transparent: true, opacity: 0.8, depthWrite: false })
+    );
+    this.scene.add(this.spicePoints);
+  }
+
+  // ---------------------------------------------------------------- input
+
+  private onKeyDown = (e: KeyboardEvent): void => {
+    if (e.repeat) return;
+    const k = e.code;
+    this.keys.add(k);
+    if (this.phase !== "playing") return;
+    if (this.isMoveKey(k)) {
+      e.preventDefault();
+      this.takeStep("step");
+      this.moveHeldTime = 0;
+      this.autoStepTimer = 0;
+    }
+    if (k === "KeyT") this.plantThumper();
+  };
+
+  private onKeyUp = (e: KeyboardEvent): void => {
+    this.keys.delete(e.code);
+  };
+
+  private isMoveKey(k: string): boolean {
+    return ["KeyW", "KeyA", "KeyS", "KeyD", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(k);
+  }
+
+  private moveDir(): THREE.Vector2 {
+    const d = new THREE.Vector2();
+    const has = (...ks: string[]) => ks.some((k) => this.keys.has(k));
+    if (has("KeyW", "ArrowUp")) d.y -= 1;
+    if (has("KeyS", "ArrowDown")) d.y += 1;
+    if (has("KeyA", "ArrowLeft")) d.x -= 1;
+    if (has("KeyD", "ArrowRight")) d.x += 1;
+    if (d.lengthSq() > 0) d.normalize();
+    return d;
+  }
+
+  private onCanvasClick = (): void => {
+    if (this.phase !== "playing") return;
+    const canvas = this.renderer.domElement;
+    if (document.pointerLockElement !== canvas) {
+      canvas.requestPointerLock?.()?.catch?.(() => {});
+    }
+  };
+
+  private onMouseMove = (e: MouseEvent): void => {
+    if (document.pointerLockElement !== this.renderer.domElement) return;
+    this.yaw -= e.movementX * 0.0022;
+    this.pitch = clamp(this.pitch - e.movementY * 0.0022, -1.2, 1.2);
+  };
+
+  private onResize = (): void => {
+    const c = this.renderer.domElement;
+    const w = c.clientWidth;
+    const h = Math.max(1, c.clientHeight);
+    this.renderer.setSize(w, h, false);
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+  };
+
+  // ---------------------------------------------------------------- player
+
+  private takeStep(kind: StepKind): void {
+    if (this.phase !== "playing") return;
+    const dir = this.moveDir();
+    if (dir.lengthSq() === 0) return;
+
+    const onRock = isOnRock(this.pos.x, this.pos.z);
+    const judge = this.rhythm.onStep(this.elapsed, kind);
+    this.steps++;
+    if (judge.label === "sandwalk" && !onRock) this.sandwalkSteps++;
+    this.stepLabelTtl = 1.4;
+    this.hud.stepLabel = judge.label;
+
+    // movement impulse in look direction
+    const impulse = kind === "run" ? 9.2 : kind === "walk" ? 6.6 : 7.6;
+    const sin = Math.sin(this.yaw);
+    const cos = Math.cos(this.yaw);
+    const wx = dir.x * cos + dir.y * sin;
+    const wz = -dir.x * sin + dir.y * cos;
+    this.vel.x += wx * impulse;
+    this.vel.z += wz * impulse;
+    this.bobPhase += Math.PI;
+    this.bob = Math.min(1, this.bob + 0.5);
+    this.audio.footstep(kind === "step" && Math.random() < 0.4 ? "drag" : kind);
+
+    if (onRock) return; // rock transmits nothing to the sand
+
+    // drum sand!
+    if (isOnDrumSand(this.pos.x, this.pos.z)) {
+      this.vibration = 1;
+      this.audio.drumBoom();
+      this.shake = Math.max(this.shake, 0.8);
+      this.showMessage("DRUM SAND! The booming rolls across the basin. RUN!", "danger", 4);
+      this.summonOrAlertWorm(3.5);
+      return;
+    }
+
+    this.vibration = clamp(this.vibration + judge.loudness, 0, 1);
+    if (this.vibration >= VIBRATION_TRIGGER && this.worm.state === "idle") {
+      this.summonOrAlertWorm(judge.loudness);
+    } else if (this.worm.state !== "idle" && judge.loudness > 0.08) {
+      this.worm.hear({ x: this.pos.x, z: this.pos.z, kind: "player" }, judge.loudness);
+    }
+  }
+
+  private summonOrAlertWorm(loudness: number): void {
+    if (this.worm.state === "idle" || this.worm.state === "leave") {
+      this.worm.call({ x: this.pos.x, z: this.pos.z, kind: "player" });
+      if (!this.wormsignAnnounced) {
+        this.wormsignAnnounced = true;
+        this.showMessage(
+          "WORMSIGN — an elongated mound-in-motion, a cresting of sand, turns toward you.",
+          "danger",
+          5
+        );
+      }
+    } else {
+      this.worm.hear({ x: this.pos.x, z: this.pos.z, kind: "player" }, loudness);
+    }
+  }
+
+  private plantThumper(): void {
+    if (this.thumperInventory <= 0) {
+      this.showMessage("No thumpers left in your Fremkit.", "info", 2.5);
+      return;
+    }
+    const fx = -Math.sin(this.yaw) * 3;
+    const fz = -Math.cos(this.yaw) * 3;
+    const x = this.pos.x + fx;
+    const z = this.pos.z + fz;
+    if (isOnRock(x, z)) {
+      this.showMessage("Plant it in open sand — rock gives no transmission.", "info", 3);
+      return;
+    }
+    this.thumperInventory--;
+    this.thumpersUsed++;
+    const group = new THREE.Group();
+    const rod = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.07, 0.05, 1.1, 8),
+      new THREE.MeshStandardMaterial({ color: 0x803f2a, roughness: 0.7 })
+    );
+    rod.position.y = 0.55;
+    group.add(rod);
+    const clapper = new THREE.Mesh(
+      new THREE.BoxGeometry(0.3, 0.14, 0.3),
+      new THREE.MeshStandardMaterial({ color: 0xd8cdb8, roughness: 0.5 })
+    );
+    clapper.position.y = 1.18;
+    group.add(clapper);
+    group.position.set(x, terrainHeight(x, z), z);
+    this.scene.add(group);
+    const t: Thumper = { id: this.nextThumperId++, x, z, mesh: group, clapper, ttl: 75, tick: 0 };
+    this.thumpers.push(t);
+    this.audio.plantThumper();
+    this.showMessage("The clapper begins its summons: lump... lump... lump...", "info", 4);
+  }
+
+  private removeThumper(id: number): void {
+    const i = this.thumpers.findIndex((t) => t.id === id);
+    if (i >= 0) {
+      this.scene.remove(this.thumpers[i].mesh);
+      this.thumpers.splice(i, 1);
+    }
+  }
+
+  // ---------------------------------------------------------------- flow
+
+  start(): void {
+    if (this.phase === "playing") return;
+    this.audio.init();
+    this.phase = "playing";
+    this.startTime = this.elapsed;
+    this.showMessage(
+      "Cross the open sand. Tap to step — keep your timing broken, like wind-shifted sand.",
+      "info",
+      6
+    );
+  }
+
+  restart(): void {
+    this.pos.set(START.x, 0, START.z);
+    this.vel.set(0, 0, 0);
+    this.yaw = Math.PI;
+    this.pitch = 0;
+    this.vibration = 0;
+    this.rhythm.reset();
+    this.worm.reset();
+    for (const t of this.thumpers) this.scene.remove(t.mesh);
+    this.thumpers = [];
+    this.thumperInventory = 2;
+    this.steps = 0;
+    this.sandwalkSteps = 0;
+    this.thumpersUsed = 0;
+    this.spiceNoticed = false;
+    this.wormsignAnnounced = false;
+    this.message = null;
+    this.phase = "playing";
+    this.startTime = this.elapsed;
+    this.audio.init();
+    this.showMessage("Again. Walk without rhythm.", "info", 4);
+  }
+
+  private die(): void {
+    if (this.phase !== "playing") return;
+    this.phase = "dead";
+    this.audio.death();
+    document.exitPointerLock?.();
+  }
+
+  private winGame(): void {
+    if (this.phase !== "playing") return;
+    this.phase = "won";
+    this.audio.win();
+    document.exitPointerLock?.();
+  }
+
+  private showMessage(text: string, tone: "info" | "danger" | "good", dur: number): void {
+    this.message = text;
+    this.messageTone = tone;
+    this.messageTtl = dur;
+  }
+
+  // ---------------------------------------------------------------- loop
+
+  private loop = (): void => {
+    if (this.disposed) return;
+    this.raf = requestAnimationFrame(this.loop);
+    const dt = Math.min(0.05, this.clock.getDelta());
+    this.elapsed += dt;
+    this.update(dt);
+    this.renderer.render(this.scene, this.camera);
+    this.onHud(this.makeHud());
+  };
+
+  private update(dt: number): void {
+    const t = this.elapsed;
+
+    if (this.phase === "intro") {
+      // slow establishing drift over the dunes
+      const a = t * 0.045;
+      const cx = START.x + Math.sin(a) * 40;
+      const cz = START.z - 60 + Math.cos(a * 0.7) * 30;
+      this.camera.position.set(cx, terrainHeight(cx, cz) + 16, cz);
+      this.camera.lookAt(0, 8, GOAL_Z);
+      this.updateAmbient(dt, t);
+      return;
+    }
+
+    if (this.phase === "playing") {
+      this.updatePlayer(dt, t);
+      this.updateThumpers(dt);
+      this.worm.update(dt, t, this.pos.x, this.pos.z);
+
+      // win check
+      if (this.pos.z < GOAL_Z + 5) this.winGame();
+    } else {
+      // dead / won: keep the world alive behind the overlay
+      this.worm.update(dt, t, this.pos.x, this.pos.z);
+    }
+
+    this.placeCamera(dt, t);
+    this.updateAmbient(dt, t);
+  }
+
+  private updatePlayer(dt: number, t: number): void {
+    const dir = this.moveDir();
+    const moving = dir.lengthSq() > 0;
+    const running = this.keys.has("ShiftLeft") || this.keys.has("ShiftRight");
+
+    if (moving) {
+      this.moveHeldTime += dt;
+      if (this.moveHeldTime > 0.35) {
+        this.autoStepTimer -= dt;
+        if (this.autoStepTimer <= 0) {
+          const kind: StepKind = running ? "run" : "walk";
+          this.autoStepTimer = running ? 0.26 : 0.44;
+          this.takeStep(kind);
+        }
+      }
+    } else {
+      this.moveHeldTime = 0;
+      this.autoStepTimer = 0;
+    }
+
+    // physics
+    const f = Math.exp(-FRICTION * dt);
+    this.vel.x *= f;
+    this.vel.z *= f;
+    this.pos.x += this.vel.x * dt;
+    this.pos.z += this.vel.z * dt;
+
+    // soft world bounds
+    if (this.pos.x < -BOUND.x || this.pos.x > BOUND.x || this.pos.z > BOUND.zMax || this.pos.z < BOUND.zMin) {
+      this.pos.x = clamp(this.pos.x, -BOUND.x, BOUND.x);
+      this.pos.z = clamp(this.pos.z, BOUND.zMin, BOUND.zMax);
+      this.showMessage("The open erg stretches to the horizon. The sietch cliffs are the only shelter.", "info", 3);
+    }
+
+    // vibration decay (faster on rock)
+    const onRock = isOnRock(this.pos.x, this.pos.z);
+    this.vibration = clamp(this.vibration - dt * (onRock ? 0.16 : 0.065), 0, 1);
+
+    if (this.stepLabelTtl > 0) {
+      this.stepLabelTtl -= dt;
+      if (this.stepLabelTtl <= 0) this.hud.stepLabel = null;
+    }
+    if (this.messageTtl > 0) {
+      this.messageTtl -= dt;
+      if (this.messageTtl <= 0) this.message = null;
+    }
+
+    // spice flavor
+    if (isOnSpice(this.pos.x, this.pos.z)) {
+      if (!this.spiceNoticed) {
+        this.spiceNoticed = true;
+        this.showMessage("Spice — the air is thick with cinnamon. Melange glitters on the sand.", "good", 4);
+      }
+    } else {
+      this.spiceNoticed = false;
+    }
+  }
+
+  private updateThumpers(dt: number): void {
+    for (const th of [...this.thumpers]) {
+      th.ttl -= dt;
+      th.tick -= dt;
+      th.clapper.position.y = 1.18 + Math.abs(Math.sin(this.elapsed * 8.7)) * 0.1;
+      if (th.tick <= 0) {
+        th.tick = 0.72;
+        // an irresistible, perfectly rhythmic summons
+        if (this.worm.state === "idle") {
+          this.worm.call({ x: th.x, z: th.z, kind: "thumper", thumperId: th.id });
+        } else {
+          this.worm.hear({ x: th.x, z: th.z, kind: "thumper", thumperId: th.id }, 1.6);
+        }
+      }
+      if (th.ttl <= 0) {
+        this.removeThumper(th.id);
+        this.showMessage("A thumper winds down, its spring spent.", "info", 3);
+      }
+    }
+  }
+
+  private placeCamera(dt: number, t: number): void {
+    const groundY = terrainHeight(this.pos.x, this.pos.z);
+    this.bob = Math.max(0, this.bob - dt * 2.2);
+    const bobY = Math.sin(this.bobPhase + t * 10) * 0.05 * this.bob;
+    this.shake = Math.max(0, this.shake - dt * 1.1);
+    // worm proximity shakes the ground
+    const wd = this.worm.state !== "idle" ? this.worm.distanceTo(this.pos.x, this.pos.z) : Infinity;
+    const proxShake = wd < 120 ? (1 - wd / 120) * 0.35 : 0;
+    const sh = this.shake + proxShake;
+    const sx = (fbm2(t * 9.1, 3.7, 2)) * sh * 0.35;
+    const sy = (fbm2(7.3, t * 8.6, 2)) * sh * 0.35;
+
+    this.camera.position.set(this.pos.x + sx, groundY + PLAYER_EYE + bobY + sy, this.pos.z);
+    const lookX = this.pos.x - Math.sin(this.yaw) * Math.cos(this.pitch);
+    const lookY = this.camera.position.y + Math.sin(this.pitch);
+    const lookZ = this.pos.z - Math.cos(this.yaw) * Math.cos(this.pitch);
+    this.camera.lookAt(lookX, lookY, lookZ);
+
+    // keyboard turning (Q/E) for mouse-free play
+    if (this.phase === "playing") {
+      if (this.keys.has("KeyQ")) this.yaw += 1.7 * dt;
+      if (this.keys.has("KeyE")) this.yaw -= 1.7 * dt;
+    }
+  }
+
+  private updateAmbient(dt: number, t: number): void {
+    // wind-blown sand drifts past the camera
+    const N = this.windData.length / 3;
+    const wx = 9 + Math.sin(t * 0.3) * 4;
+    const wz = 3 + Math.cos(t * 0.21) * 2;
+    const cx = this.camera.position.x;
+    const cy = this.camera.position.y;
+    const cz = this.camera.position.z;
+    for (let i = 0; i < N; i++) {
+      let x = this.windData[i * 3] + wx * dt * (0.6 + (i % 5) * 0.2);
+      let y = this.windData[i * 3 + 1] + Math.sin(t * 2 + i) * dt * 1.5;
+      let z = this.windData[i * 3 + 2] + wz * dt;
+      if (x - cx > 70) x -= 140;
+      if (x - cx < -70) x += 140;
+      if (z - cz > 70) z -= 140;
+      if (z - cz < -70) z += 140;
+      if (y > cy + 22) y = cy - 4;
+      if (y < cy - 8) y = cy + 18;
+      this.windData[i * 3] = x;
+      this.windData[i * 3 + 1] = y;
+      this.windData[i * 3 + 2] = z;
+    }
+    (this.windPoints.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+
+    // spice twinkle
+    const sm = this.spicePoints.material as THREE.PointsMaterial;
+    sm.opacity = 0.45 + Math.abs(Math.sin(t * 2.3)) * 0.45;
+    sm.size = 0.3 + Math.abs(Math.sin(t * 1.7)) * 0.18;
+
+    // audio ambience
+    const wormDist = this.worm.state !== "idle" ? this.worm.distanceTo(this.pos.x, this.pos.z) : Infinity;
+    let nearestThumper: number | null = null;
+    for (const th of this.thumpers) {
+      const d = Math.hypot(th.x - this.pos.x, th.z - this.pos.z);
+      nearestThumper = nearestThumper === null ? d : Math.min(nearestThumper, d);
+    }
+    this.audio.update(dt, t, wormDist, this.worm.state !== "idle", nearestThumper);
+  }
+
+  // ---------------------------------------------------------------- hud
+
+  private makeHud(): HudState {
+    const wormActive = this.worm.state !== "idle";
+    return {
+      phase: this.phase,
+      vibration: this.vibration,
+      stepLabel: this.stepLabelTtl > 0 ? this.hud?.stepLabel ?? null : null,
+      wormState: this.worm.state,
+      wormDistance: wormActive ? this.worm.distanceTo(this.pos.x, this.pos.z) : null,
+      distanceToGoal: Math.max(0, this.pos.z - (GOAL_Z + 5)),
+      thumpers: this.thumperInventory,
+      onRock: isOnRock(this.pos.x, this.pos.z),
+      onSpice: isOnSpice(this.pos.x, this.pos.z),
+      message: this.message,
+      messageTone: this.messageTone,
+      stats: {
+        time: this.phase === "intro" ? 0 : this.elapsed - this.startTime,
+        steps: this.steps,
+        sandwalkSteps: this.sandwalkSteps,
+        wormsCalled: this.worm.timesCalled,
+        thumpersUsed: this.thumpersUsed,
+      },
+    };
+  }
+
+  // ---------------------------------------------------------------- tests
+
+  private installTestHooks(): void {
+    const api = {
+      getState: () => ({
+        phase: this.phase,
+        x: this.pos.x,
+        z: this.pos.z,
+        vibration: this.vibration,
+        worm: {
+          state: this.worm.state,
+          x: this.worm.pos.x,
+          z: this.worm.pos.y,
+          dist: this.worm.state !== "idle" ? this.worm.distanceTo(this.pos.x, this.pos.z) : null,
+          timesCalled: this.worm.timesCalled,
+        },
+        thumpers: this.thumperInventory,
+        activeThumpers: this.thumpers.length,
+        onRock: isOnRock(this.pos.x, this.pos.z),
+        steps: this.steps,
+        sandwalkSteps: this.sandwalkSteps,
+        message: this.message,
+      }),
+      start: () => this.start(),
+      restart: () => this.restart(),
+      teleport: (x: number, z: number) => {
+        this.pos.set(x, 0, z);
+        this.vel.set(0, 0, 0);
+      },
+      setYaw: (y: number) => {
+        this.yaw = y;
+      },
+      setVibration: (v: number) => {
+        this.vibration = clamp(v, 0, 1);
+      },
+      plantThumper: () => this.plantThumper(),
+    };
+    (window as unknown as Record<string, unknown>).__DUNE__ = api;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    cancelAnimationFrame(this.raf);
+    window.removeEventListener("keydown", this.onKeyDown);
+    window.removeEventListener("keyup", this.onKeyUp);
+    window.removeEventListener("resize", this.onResize);
+    this.renderer.domElement.removeEventListener("click", this.onCanvasClick);
+    document.removeEventListener("mousemove", this.onMouseMove);
+    this.audio.dispose();
+    this.renderer.dispose();
+    delete (window as unknown as Record<string, unknown>).__DUNE__;
+  }
+}

--- a/src/lib/dune/game.ts
+++ b/src/lib/dune/game.ts
@@ -20,6 +20,7 @@ import {
 } from "./world";
 import { fbm2, clamp, lerp } from "./noise";
 import { RhythmTracker, StepKind } from "./rhythm";
+import { makeDotTexture } from "./dot-texture";
 import { SandWorm, WormState, WORM_KILL_RADIUS } from "./worm";
 import { DuneAudio } from "./audio";
 
@@ -72,7 +73,7 @@ export class DuneGame {
   // player
   private pos = new THREE.Vector3(START.x, 0, START.z);
   private vel = new THREE.Vector3();
-  private yaw = Math.PI; // facing -z (toward the sietch)
+  private yaw = 0; // facing -z (toward the sietch)
   private pitch = 0;
   private keys = new Set<string>();
   private moveHeldTime = 0;
@@ -121,7 +122,7 @@ export class DuneGame {
     this.renderer.toneMappingExposure = 1.05;
 
     this.scene = new THREE.Scene();
-    this.scene.fog = new THREE.FogExp2(0xcf9a64, 0.00115);
+    this.scene.fog = new THREE.FogExp2(0xcf9a64, 0.00145);
 
     this.camera = new THREE.PerspectiveCamera(
       72,
@@ -229,7 +230,7 @@ export class DuneGame {
     sg.setAttribute("position", new THREE.BufferAttribute(sp, 3));
     const stars = new THREE.Points(
       sg,
-      new THREE.PointsMaterial({ color: 0xdde6ff, size: 3.2, sizeAttenuation: false, transparent: true, opacity: 0.75, fog: false, depthWrite: false })
+      new THREE.PointsMaterial({ color: 0xdde6ff, size: 2.4, sizeAttenuation: false, map: makeDotTexture(), transparent: true, opacity: 0.7, fog: false, depthWrite: false })
     );
     this.scene.add(stars);
 
@@ -300,7 +301,7 @@ export class DuneGame {
 
       // drum sand: paler, smoother, slightly grey — visibly taut
       const df = drumFactor(x, z);
-      if (df > 0) cBase.lerp(new THREE.Color(0.93, 0.88, 0.72), df * 0.85);
+      if (df > 0) cBase.lerp(new THREE.Color(0.97, 0.94, 0.82), df * 0.95);
 
       // spice: rust-cinnamon stain
       const sf = spiceFactor(x, z);
@@ -320,34 +321,46 @@ export class DuneGame {
     geo.computeVertexNormals();
     const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 1, metalness: 0 });
     this.scene.add(new THREE.Mesh(geo, mat));
+
+    // endless-erg illusion: a vast sand disc under and beyond the heightfield
+    const far = new THREE.Mesh(
+      new THREE.CircleGeometry(4200, 48),
+      new THREE.MeshStandardMaterial({ color: 0xc1854e, roughness: 1 })
+    );
+    far.rotation.x = -Math.PI / 2;
+    far.position.y = -7; // below the heightfield's lowest valley
+    this.scene.add(far);
   }
 
   private buildRocks(): void {
-    const rockMat = new THREE.MeshStandardMaterial({ color: 0x453a31, roughness: 0.95, flatShading: true });
-    const addBoulders = (cx: number, cz: number, r: number, count: number) => {
+    const rockMat = new THREE.MeshStandardMaterial({ color: 0x5d4e41, roughness: 0.95, flatShading: true });
+    const addBoulders = (cx: number, cz: number, r: number, count: number, keepExitClear: boolean) => {
       for (let i = 0; i < count; i++) {
         const a = Math.random() * Math.PI * 2;
-        const rr = r * (0.45 + Math.random() * 0.65);
+        // leave the southern exit (toward the sietch, -z) free of boulders
+        if (keepExitClear && Math.sin(a) < -0.25) continue;
+        const rr = r * (0.55 + Math.random() * 0.55);
         const x = cx + Math.cos(a) * rr;
         const z = cz + Math.sin(a) * rr;
-        const s = 0.8 + Math.random() * 2.6;
+        const s = 0.8 + Math.random() * 2.2;
         const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(s, 0), rockMat);
-        rock.position.set(x, terrainHeight(x, z) + s * 0.25, z);
+        rock.position.set(x, terrainHeight(x, z) + s * 0.2, z);
         rock.rotation.set(Math.random() * 3, Math.random() * 3, Math.random() * 3);
         rock.scale.y = 0.6 + Math.random() * 0.5;
         this.scene.add(rock);
       }
     };
-    addBoulders(START.x, START.z, START.r, 14);
-    for (const rf of REFUGES) addBoulders(rf.x, rf.z, rf.r, 9);
-    // jagged crags along the cliff top
-    for (let i = 0; i < 40; i++) {
-      const x = -640 + Math.random() * 1280;
-      const z = CLIFF_Z - 70 - Math.random() * 90;
-      const s = 8 + Math.random() * 26;
-      const crag = new THREE.Mesh(new THREE.ConeGeometry(s * 0.7, s * 2.4, 5), rockMat);
-      crag.position.set(x, terrainHeight(x, z) + s * 0.6, z);
+    addBoulders(START.x, START.z, START.r, 16, true);
+    for (const rf of REFUGES) addBoulders(rf.x, rf.z, rf.r, 8, true);
+    // a broad rocky massif above the cliff line — the sietch wall
+    for (let i = 0; i < 64; i++) {
+      const x = -700 + Math.random() * 1400;
+      const z = CLIFF_Z - 90 - Math.random() * 160;
+      const s = 16 + Math.random() * 42;
+      const crag = new THREE.Mesh(new THREE.ConeGeometry(s * (1.3 + Math.random() * 0.9), s * (1.4 + Math.random()), 6), rockMat);
+      crag.position.set(x, terrainHeight(x, z) + s * 0.35, z);
       crag.rotation.y = Math.random() * 3;
+      crag.scale.x = 1 + Math.random() * 1.4;
       this.scene.add(crag);
     }
   }
@@ -369,18 +382,18 @@ export class DuneGame {
   }
 
   private buildWind(): void {
-    const N = 800;
+    const N = 700;
     this.windData = new Float32Array(N * 3);
     for (let i = 0; i < N; i++) {
       this.windData[i * 3] = (Math.random() - 0.5) * 140;
-      this.windData[i * 3 + 1] = Math.random() * 26;
+      this.windData[i * 3 + 1] = Math.random() * 7; // skim low over the sand
       this.windData[i * 3 + 2] = (Math.random() - 0.5) * 140;
     }
     const geo = new THREE.BufferGeometry();
     geo.setAttribute("position", new THREE.BufferAttribute(this.windData, 3));
     this.windPoints = new THREE.Points(
       geo,
-      new THREE.PointsMaterial({ color: 0xe2bb86, size: 0.45, transparent: true, opacity: 0.5, depthWrite: false })
+      new THREE.PointsMaterial({ color: 0xd9b486, size: 0.32, map: makeDotTexture(), transparent: true, opacity: 0.32, depthWrite: false })
     );
     this.scene.add(this.windPoints);
   }
@@ -496,8 +509,11 @@ export class DuneGame {
       this.vibration = 1;
       this.audio.drumBoom();
       this.shake = Math.max(this.shake, 0.8);
-      this.showMessage("DRUM SAND! The booming rolls across the basin. RUN!", "danger", 4);
+      this.stepLabelTtl = 0; // the boom drowns out any step judgement
+      this.hud.stepLabel = null;
+      this.wormsignAnnounced = true; // the boom says it all
       this.summonOrAlertWorm(3.5);
+      this.showMessage("DRUM SAND! The booming rolls across the basin. RUN!", "danger", 4);
       return;
     }
 
@@ -586,7 +602,7 @@ export class DuneGame {
   restart(): void {
     this.pos.set(START.x, 0, START.z);
     this.vel.set(0, 0, 0);
-    this.yaw = Math.PI;
+    this.yaw = 0;
     this.pitch = 0;
     this.vibration = 0;
     this.rhythm.reset();
@@ -653,7 +669,7 @@ export class DuneGame {
     }
 
     if (this.phase === "playing") {
-      this.updatePlayer(dt, t);
+      this.updatePlayer(dt);
       this.updateThumpers(dt);
       this.worm.update(dt, t, this.pos.x, this.pos.z);
 
@@ -668,7 +684,7 @@ export class DuneGame {
     this.updateAmbient(dt, t);
   }
 
-  private updatePlayer(dt: number, t: number): void {
+  private updatePlayer(dt: number): void {
     const dir = this.moveDir();
     const moving = dir.lengthSq() > 0;
     const running = this.keys.has("ShiftLeft") || this.keys.has("ShiftRight");
@@ -704,7 +720,7 @@ export class DuneGame {
 
     // vibration decay (faster on rock)
     const onRock = isOnRock(this.pos.x, this.pos.z);
-    this.vibration = clamp(this.vibration - dt * (onRock ? 0.16 : 0.065), 0, 1);
+    this.vibration = clamp(this.vibration - dt * (onRock ? 0.16 : 0.075), 0, 1);
 
     if (this.stepLabelTtl > 0) {
       this.stepLabelTtl -= dt;
@@ -788,8 +804,9 @@ export class DuneGame {
       if (x - cx < -70) x += 140;
       if (z - cz > 70) z -= 140;
       if (z - cz < -70) z += 140;
-      if (y > cy + 22) y = cy - 4;
-      if (y < cy - 8) y = cy + 18;
+      // drift low over the sand near the player
+      if (y > cy + 6) y = cy - 3;
+      if (y < cy - 4) y = cy + 5;
       this.windData[i * 3] = x;
       this.windData[i * 3 + 1] = y;
       this.windData[i * 3 + 2] = z;

--- a/src/lib/dune/noise.ts
+++ b/src/lib/dune/noise.ts
@@ -1,0 +1,57 @@
+// Deterministic 2D value noise + fBm. No dependencies, identical results
+// every run so terrain physics and rendering always agree.
+
+function hash2(ix: number, iy: number): number {
+  let h = ix * 374761393 + iy * 668265263;
+  h = (h ^ (h >> 13)) * 1274126177;
+  h = h ^ (h >> 16);
+  // map to [-1, 1]
+  return ((h >>> 0) % 100000) / 50000 - 1;
+}
+
+function smooth(t: number): number {
+  return t * t * (3 - 2 * t);
+}
+
+/** Single octave of 2D value noise, output in [-1, 1]. */
+export function noise2(x: number, y: number): number {
+  const ix = Math.floor(x);
+  const iy = Math.floor(y);
+  const fx = x - ix;
+  const fy = y - iy;
+  const a = hash2(ix, iy);
+  const b = hash2(ix + 1, iy);
+  const c = hash2(ix, iy + 1);
+  const d = hash2(ix + 1, iy + 1);
+  const ux = smooth(fx);
+  const uy = smooth(fy);
+  return a + (b - a) * ux + (c - a) * uy + (a - b - c + d) * ux * uy;
+}
+
+/** Fractal Brownian motion, output roughly in [-1, 1]. */
+export function fbm2(x: number, y: number, octaves = 4): number {
+  let total = 0;
+  let amp = 0.5;
+  let freq = 1;
+  let norm = 0;
+  for (let i = 0; i < octaves; i++) {
+    total += noise2(x * freq, y * freq) * amp;
+    norm += amp;
+    amp *= 0.5;
+    freq *= 2.07;
+  }
+  return total / norm;
+}
+
+export function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+export function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/src/lib/dune/rhythm.ts
+++ b/src/lib/dune/rhythm.ts
@@ -21,7 +21,7 @@ export interface StepJudgement {
 }
 
 const BASE_LOUDNESS: Record<StepKind, number> = {
-  step: 0.045, // a single deliberate footfall
+  step: 0.035, // a single deliberate footfall
   walk: 0.055, // continuous walking pace
   run: 0.115, // pounding run
 };
@@ -44,7 +44,8 @@ export class RhythmTracker {
     if (this.times.length > WINDOW) this.times.shift();
 
     const rhythm = this.measure(kind);
-    const loud = BASE_LOUDNESS[kind] * lerp(0.32, 3.4, rhythm);
+    // a true sandwalk reads as natural sand-shift: nearly silent
+    const loud = BASE_LOUDNESS[kind] * lerp(0.2, 3.4, rhythm);
     const label = rhythm < 0.34 ? "sandwalk" : rhythm < 0.62 ? "uneven" : "rhythmic";
     return { rhythm, loudness: loud, label };
   }
@@ -53,6 +54,13 @@ export class RhythmTracker {
   private measure(kind: StepKind): number {
     // Running is always pounding and loud regardless of timing.
     if (kind === "run") return 1;
+    // A continuous walking gait is inherently rhythmic — only deliberate
+    // single steps with broken timing can pass as natural sand-shift.
+    if (kind === "walk") return Math.max(0.8, this.measureTimings());
+    return this.measureTimings();
+  }
+
+  private measureTimings(): number {
     const n = this.times.length;
     if (n < 3) return 0.18; // too few footfalls to form a pattern
     const intervals: number[] = [];

--- a/src/lib/dune/rhythm.ts
+++ b/src/lib/dune/rhythm.ts
@@ -1,0 +1,69 @@
+// "We must walk without rhythm... they must sound like the natural shifting
+// of sand... like the wind." — Dune, ch. 21
+//
+// Tracks the timing of the player's footfalls. Regular intervals = rhythm =
+// loud to a worm. Broken, irregular intervals (step... drag... wait... step)
+// read as natural sand-shift and are nearly silent.
+
+import { clamp, lerp } from "./noise";
+
+const WINDOW = 6; // steps considered
+const MAX_GAP = 2.4; // a pause longer than this breaks any rhythm
+
+export type StepKind = "step" | "walk" | "run";
+
+export interface StepJudgement {
+  /** 0 = perfect sandwalk, 1 = mechanical rhythm */
+  rhythm: number;
+  /** vibration loudness this footfall transmits through the sand */
+  loudness: number;
+  label: "sandwalk" | "uneven" | "rhythmic";
+}
+
+const BASE_LOUDNESS: Record<StepKind, number> = {
+  step: 0.045, // a single deliberate footfall
+  walk: 0.055, // continuous walking pace
+  run: 0.115, // pounding run
+};
+
+export class RhythmTracker {
+  private times: number[] = [];
+
+  reset(): void {
+    this.times = [];
+  }
+
+  /** Register a footfall at time t (seconds). Returns how a worm hears it. */
+  onStep(t: number, kind: StepKind): StepJudgement {
+    const last = this.times[this.times.length - 1];
+    if (last !== undefined && t - last > MAX_GAP) {
+      // long pause: rhythm broken, start fresh
+      this.times = [];
+    }
+    this.times.push(t);
+    if (this.times.length > WINDOW) this.times.shift();
+
+    const rhythm = this.measure(kind);
+    const loud = BASE_LOUDNESS[kind] * lerp(0.32, 3.4, rhythm);
+    const label = rhythm < 0.34 ? "sandwalk" : rhythm < 0.62 ? "uneven" : "rhythmic";
+    return { rhythm, loudness: loud, label };
+  }
+
+  /** Current rhythm estimate 0..1 (1 = metronome). */
+  private measure(kind: StepKind): number {
+    // Running is always pounding and loud regardless of timing.
+    if (kind === "run") return 1;
+    const n = this.times.length;
+    if (n < 3) return 0.18; // too few footfalls to form a pattern
+    const intervals: number[] = [];
+    for (let i = 1; i < n; i++) intervals.push(this.times[i] - this.times[i - 1]);
+    const recent = intervals.slice(-4);
+    const mean = recent.reduce((a, b) => a + b, 0) / recent.length;
+    if (mean <= 0) return 1;
+    const variance =
+      recent.reduce((a, b) => a + (b - mean) * (b - mean), 0) / recent.length;
+    const cv = Math.sqrt(variance) / mean; // coefficient of variation
+    // cv >= 0.42 → convincing sandwalk; cv <= 0.07 → metronome
+    return clamp(1 - (cv - 0.07) / (0.42 - 0.07), 0, 1);
+  }
+}

--- a/src/lib/dune/world.ts
+++ b/src/lib/dune/world.ts
@@ -53,8 +53,8 @@ export function duneHeight(x: number, z: number): number {
   const warp = fbm2(x * 0.004 + 11.3, z * 0.004 - 4.7, 3) * 120;
   // long crescent dune rows running roughly east-west, ~230m wavelength
   const ridge = Math.sin((z + warp) * 0.027 + fbm2(x * 0.012, z * 0.012, 3) * 2.2);
-  let h = Math.pow((ridge + 1) / 2, 1.6) * 9.5;
-  h += fbm2(x * 0.016 + 7.1, z * 0.016 - 3.4, 4) * 4.2;
+  let h = Math.pow((ridge + 1) / 2, 1.6) * 13.5;
+  h += fbm2(x * 0.016 + 7.1, z * 0.016 - 3.4, 4) * 5.5;
   h += fbm2(x * 0.085 + 1.7, z * 0.085 + 9.2, 2) * 0.55;
   return h;
 }

--- a/src/lib/dune/world.ts
+++ b/src/lib/dune/world.ts
@@ -1,0 +1,127 @@
+// The world of Arrakis: analytic heightfield + zone definitions shared by
+// rendering, player physics and worm AI.
+
+import { fbm2, smoothstep, clamp } from "./noise";
+
+export const WORLD_SIZE = 1500;
+
+/** Player starting rock islet. */
+export const START = { x: 0, z: 250, r: 22 };
+
+/** Reaching this z means the cliffs of the sietch: safety / victory. */
+export const GOAL_Z = -250;
+export const CLIFF_Z = -270; // where the cliff wall begins to rise
+
+/** Small rock refuges scattered along the crossing. Worms cannot reach rock. */
+export const REFUGES: { x: number; z: number; r: number }[] = [
+  { x: -68, z: 138, r: 13 },
+  { x: 55, z: 16, r: 12 },
+  { x: -42, z: -120, r: 13 },
+];
+
+/** Drum sand: taut, pale patches that BOOM when stepped on (instant wormsign). */
+export const DRUM_PATCHES: { x: number; z: number; r: number }[] = [
+  { x: -14, z: 190, r: 12 },
+  { x: 30, z: 96, r: 14 },
+  { x: -52, z: 58, r: 11 },
+  { x: 12, z: -36, r: 13 },
+  { x: -20, z: -88, r: 10 },
+  { x: 58, z: -150, r: 14 },
+  { x: -6, z: -196, r: 12 },
+  { x: 96, z: -60, r: 12 },
+];
+
+/** Spice blows: rust-cinnamon shimmer on the sand. Cosmetic + flavor text. */
+export const SPICE_PATCHES: { x: number; z: number; r: number }[] = [
+  { x: -110, z: 80, r: 24 },
+  { x: 88, z: -10, r: 20 },
+  { x: -70, z: -180, r: 22 },
+  { x: 130, z: 150, r: 26 },
+];
+
+/** Soft playfield boundary; beyond this the player is nudged back. */
+export const BOUND = { x: 420, zMin: -320, zMax: 330 };
+
+function rockPad(x: number, z: number, cx: number, cz: number, r: number): number {
+  const d = Math.hypot(x - cx, z - cz);
+  // flat-topped pad, ~2.6m above the surrounding sand
+  return smoothstep(r + 10, r - 4, d) * 2.6;
+}
+
+/** Pure dune field height (no rock features). */
+export function duneHeight(x: number, z: number): number {
+  const warp = fbm2(x * 0.004 + 11.3, z * 0.004 - 4.7, 3) * 120;
+  // long crescent dune rows running roughly east-west, ~230m wavelength
+  const ridge = Math.sin((z + warp) * 0.027 + fbm2(x * 0.012, z * 0.012, 3) * 2.2);
+  let h = Math.pow((ridge + 1) / 2, 1.6) * 9.5;
+  h += fbm2(x * 0.016 + 7.1, z * 0.016 - 3.4, 4) * 4.2;
+  h += fbm2(x * 0.085 + 1.7, z * 0.085 + 9.2, 2) * 0.55;
+  return h;
+}
+
+/** Full terrain height: dunes + rock pads + sietch cliff wall. */
+export function terrainHeight(x: number, z: number): number {
+  let h = duneHeight(x, z);
+  h += rockPad(x, z, START.x, START.z, START.r);
+  for (const rf of REFUGES) h += rockPad(x, z, rf.x, rf.z, rf.r);
+  // sietch cliff: rises steeply past CLIFF_Z, with a rocky apron before it
+  const cliff = smoothstep(CLIFF_Z, CLIFF_Z - 90, z);
+  h += cliff * cliff * 90;
+  h += smoothstep(GOAL_Z + 14, GOAL_Z - 10, z) * 2.0; // rock apron
+  return h;
+}
+
+/** Worms cannot move through rock; the player is safe here. */
+export function isOnRock(x: number, z: number): boolean {
+  if (z < GOAL_Z + 6) return true;
+  if (Math.hypot(x - START.x, z - START.z) < START.r) return true;
+  for (const rf of REFUGES) {
+    if (Math.hypot(x - rf.x, z - rf.z) < rf.r) return true;
+  }
+  return false;
+}
+
+export function isOnDrumSand(x: number, z: number): boolean {
+  if (isOnRock(x, z)) return false;
+  for (const p of DRUM_PATCHES) {
+    if (Math.hypot(x - p.x, z - p.z) < p.r) return true;
+  }
+  return false;
+}
+
+export function isOnSpice(x: number, z: number): boolean {
+  for (const p of SPICE_PATCHES) {
+    if (Math.hypot(x - p.x, z - p.z) < p.r) return true;
+  }
+  return false;
+}
+
+/** 0..1 factor of how strongly a point sits inside any drum patch (for tinting). */
+export function drumFactor(x: number, z: number): number {
+  let f = 0;
+  for (const p of DRUM_PATCHES) {
+    const d = Math.hypot(x - p.x, z - p.z);
+    f = Math.max(f, smoothstep(p.r, p.r - 6, d));
+  }
+  return f;
+}
+
+export function spiceFactor(x: number, z: number): number {
+  let f = 0;
+  for (const p of SPICE_PATCHES) {
+    const d = Math.hypot(x - p.x, z - p.z);
+    f = Math.max(f, smoothstep(p.r, p.r - 10, d));
+  }
+  return f;
+}
+
+export function rockFactor(x: number, z: number): number {
+  let f = 0;
+  const pads = [START, ...REFUGES];
+  for (const p of pads) {
+    const d = Math.hypot(x - p.x, z - p.z);
+    f = Math.max(f, smoothstep(p.r + 8, p.r - 4, d));
+  }
+  f = Math.max(f, smoothstep(GOAL_Z + 16, GOAL_Z - 6, z));
+  return clamp(f, 0, 1);
+}

--- a/src/lib/dune/worm.ts
+++ b/src/lib/dune/worm.ts
@@ -1,0 +1,302 @@
+// Shai-Hulud. While travelling it shows only wormsign: "an elongated
+// mound-in-motion — a cresting of sand" trailing a dust hiss. When it reaches
+// rhythmic vibration on open sand it breaches: a vast round mouth ringed with
+// crystal teeth.
+
+import * as THREE from "three";
+import { terrainHeight, isOnRock } from "./world";
+import { clamp, lerp } from "./noise";
+
+export type WormState =
+  | "idle" // no worm in the area
+  | "approach" // homing on a vibration source
+  | "search" // lost the trail, casting about
+  | "breach" // surfacing attack animation
+  | "leave"; // departing / sated
+
+export interface WormTarget {
+  x: number;
+  z: number;
+  kind: "player" | "thumper";
+  thumperId?: number;
+}
+
+const SPAWN_DIST = 620;
+const DESPAWN_DIST = 950;
+const SEARCH_TIME = 11;
+const BREACH_TRIGGER_DIST = 16;
+const BREACH_DURATION = 2.6;
+const KILL_RADIUS = 30;
+
+export class SandWorm {
+  state: WormState = "idle";
+  pos = new THREE.Vector2(0, 0);
+  private heading = new THREE.Vector2(0, 1);
+  target: WormTarget | null = null;
+  private searchClock = 0;
+  private breachClock = 0;
+  private breachAt = new THREE.Vector2();
+  private satedClock = 0;
+  /** number of times the player has drawn a worm (for stats) */
+  timesCalled = 0;
+
+  group: THREE.Group;
+  private mound: THREE.Mesh;
+  private wake: THREE.Mesh;
+  private body: THREE.Group;
+  private dust: THREE.Points;
+  private dustPositions: Float32Array;
+  private dustSeeds: Float32Array;
+
+  onBreachStart: ((x: number, z: number, kind: "player" | "thumper") => void) | null = null;
+  onBreachHit: ((x: number, z: number, kind: "player" | "thumper", thumperId?: number) => void) | null = null;
+  onDeparted: (() => void) | null = null;
+
+  constructor(scene: THREE.Scene) {
+    this.group = new THREE.Group();
+    this.group.visible = false;
+    scene.add(this.group);
+
+    // --- the moving mound (wormsign)
+    const moundGeo = new THREE.SphereGeometry(1, 24, 16);
+    const moundMat = new THREE.MeshStandardMaterial({ color: 0xc08b52, roughness: 1, flatShading: false });
+    this.mound = new THREE.Mesh(moundGeo, moundMat);
+    this.mound.scale.set(13, 4.4, 30);
+    this.group.add(this.mound);
+
+    const wakeMat = new THREE.MeshStandardMaterial({ color: 0xb37f49, roughness: 1, transparent: true, opacity: 0.85 });
+    this.wake = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 10), wakeMat);
+    this.wake.scale.set(8, 2.2, 46);
+    this.wake.position.z = -30;
+    this.group.add(this.wake);
+
+    // --- dust hiss particles around the cresting head
+    const DUST = 260;
+    this.dustPositions = new Float32Array(DUST * 3);
+    this.dustSeeds = new Float32Array(DUST);
+    for (let i = 0; i < DUST; i++) this.dustSeeds[i] = Math.random();
+    const dustGeo = new THREE.BufferGeometry();
+    dustGeo.setAttribute("position", new THREE.BufferAttribute(this.dustPositions, 3));
+    const dustMat = new THREE.PointsMaterial({
+      color: 0xd9b07a,
+      size: 1.6,
+      transparent: true,
+      opacity: 0.55,
+      depthWrite: false,
+      sizeAttenuation: true,
+    });
+    this.dust = new THREE.Points(dustGeo, dustMat);
+    this.group.add(this.dust);
+
+    // --- breaching body: segmented trunk + maw of crystal teeth
+    this.body = new THREE.Group();
+    const skin = new THREE.MeshStandardMaterial({ color: 0x8a6a4a, roughness: 0.95 });
+    const skinDark = new THREE.MeshStandardMaterial({ color: 0x6e5238, roughness: 1 });
+    const SEGMENTS = 9;
+    for (let i = 0; i < SEGMENTS; i++) {
+      const t = i / (SEGMENTS - 1);
+      const r = lerp(10.5, 13.5, t);
+      const seg = new THREE.Mesh(new THREE.CylinderGeometry(r, r * 1.04, 6.4, 28), i % 2 ? skin : skinDark);
+      seg.position.y = -i * 6.1;
+      this.body.add(seg);
+    }
+    // the maw
+    const maw = new THREE.Group();
+    const throat = new THREE.Mesh(
+      new THREE.CylinderGeometry(8.2, 2.4, 10, 24),
+      new THREE.MeshBasicMaterial({ color: 0x140a06 })
+    );
+    throat.position.y = 1.0;
+    maw.add(throat);
+    const lip = new THREE.Mesh(new THREE.TorusGeometry(10.6, 2.6, 14, 30), skin);
+    lip.rotation.x = Math.PI / 2;
+    lip.position.y = 5.4;
+    maw.add(lip);
+    const toothMat = new THREE.MeshStandardMaterial({ color: 0xf2ead8, roughness: 0.35, metalness: 0.1 });
+    const TEETH = 26;
+    for (let ring = 0; ring < 2; ring++) {
+      const rr = ring === 0 ? 8.6 : 6.2;
+      for (let i = 0; i < TEETH; i++) {
+        const a = (i / TEETH) * Math.PI * 2 + ring * 0.12;
+        const tooth = new THREE.Mesh(new THREE.ConeGeometry(0.85, 4.4, 6), toothMat);
+        tooth.position.set(Math.cos(a) * rr, 4.6 - ring * 1.6, Math.sin(a) * rr);
+        tooth.lookAt(0, -4, 0);
+        maw.add(tooth);
+      }
+    }
+    maw.position.y = 6.0;
+    this.body.add(maw);
+    this.body.visible = false;
+    this.group.add(this.body);
+  }
+
+  /** Spawn over the horizon, approaching the given target point. */
+  call(target: WormTarget, fromAngleHint: number | null = null): void {
+    if (this.state === "breach") return;
+    if (this.state === "idle" || this.state === "leave") {
+      const a = fromAngleHint ?? Math.random() * Math.PI * 2;
+      this.pos.set(target.x + Math.cos(a) * SPAWN_DIST, target.z + Math.sin(a) * SPAWN_DIST);
+      this.timesCalled++;
+      this.group.visible = true;
+    }
+    this.target = { ...target };
+    this.state = "approach";
+    this.searchClock = 0;
+  }
+
+  /** A vibration the worm can hear: retarget if loud enough / closer source. */
+  hear(target: WormTarget, loudness: number): void {
+    if (this.state === "idle" || this.state === "breach") return;
+    if (this.satedClock > 0 && target.kind === "player" && loudness < 0.5) return;
+    const d = Math.hypot(this.pos.x - target.x, this.pos.y - target.z);
+    // hearing falls off with distance; thumpers and drum sand are very loud
+    const heard = loudness * clamp(1 - d / 1400, 0, 1);
+    if (heard > 0.018) {
+      this.target = { ...target };
+      if (this.state === "search" || this.state === "leave") this.state = "approach";
+      this.searchClock = 0;
+    }
+  }
+
+  get distanceTo(): (x: number, z: number) => number {
+    return (x, z) => Math.hypot(this.pos.x - x, this.pos.y - z);
+  }
+
+  update(dt: number, elapsed: number, playerX: number, playerZ: number): void {
+    if (this.satedClock > 0) this.satedClock -= dt;
+    if (this.state === "idle") return;
+
+    if (this.state === "breach") {
+      this.breachClock += dt;
+      const t = this.breachClock / BREACH_DURATION;
+      this.animateBreach(clamp(t, 0, 1));
+      if (this.breachClock > 0.85 && this.breachClock - dt <= 0.85) {
+        // the strike lands
+        this.onBreachHit?.(
+          this.breachAt.x,
+          this.breachAt.y,
+          this.target?.kind ?? "player",
+          this.target?.thumperId
+        );
+      }
+      if (t >= 1) {
+        this.body.visible = false;
+        this.mound.visible = true;
+        this.wake.visible = true;
+        this.satedClock = 14;
+        this.state = "leave";
+        this.target = null;
+      }
+      return;
+    }
+
+    let speed = 0;
+    if (this.state === "approach" && this.target) {
+      const dx = this.target.x - this.pos.x;
+      const dz = this.target.z - this.pos.y;
+      const d = Math.hypot(dx, dz);
+      speed = d > 220 ? 46 : d > 80 ? 30 : 17;
+      if (d > 1) {
+        this.heading.set(dx / d, dz / d).normalize();
+      }
+      if (d < BREACH_TRIGGER_DIST) {
+        const onRock =
+          this.target.kind === "player" ? isOnRock(this.target.x, this.target.z) : false;
+        if (onRock) {
+          // it circles, balked by rock
+          this.state = "search";
+          this.searchClock = 0;
+        } else {
+          this.state = "breach";
+          this.breachClock = 0;
+          this.breachAt.set(this.target.x, this.target.z);
+          this.body.visible = true;
+          this.mound.visible = false;
+          this.wake.visible = false;
+          this.onBreachStart?.(this.target.x, this.target.z, this.target.kind);
+        }
+      }
+    } else if (this.state === "search") {
+      this.searchClock += dt;
+      speed = 14;
+      // spiral around the last known vibration
+      const a = elapsed * 0.55;
+      this.heading.set(Math.cos(a), Math.sin(a));
+      if (this.searchClock > SEARCH_TIME) {
+        this.state = "leave";
+        this.target = null;
+      }
+    } else if (this.state === "leave") {
+      speed = 34;
+      // head away from the player
+      const dx = this.pos.x - playerX;
+      const dz = this.pos.y - playerZ;
+      const d = Math.max(1, Math.hypot(dx, dz));
+      this.heading.set(dx / d, dz / d);
+      if (d > DESPAWN_DIST) {
+        this.state = "idle";
+        this.group.visible = false;
+        this.onDeparted?.();
+        return;
+      }
+    }
+
+    this.pos.x += this.heading.x * speed * dt;
+    this.pos.y += this.heading.y * speed * dt;
+
+    // worms keep to sand: deflect away from the cliff line
+    if (this.pos.y < -230 && this.state !== "leave") {
+      this.pos.y = -230;
+    }
+
+    // place wormsign on the terrain
+    const h = terrainHeight(this.pos.x, this.pos.y);
+    this.group.position.set(this.pos.x, h - 1.5, this.pos.y);
+    const angle = Math.atan2(this.heading.x, this.heading.y);
+    this.group.rotation.y = angle;
+    // mound undulates as it swims
+    const sway = Math.sin(elapsed * 3.1) * 0.5;
+    this.mound.position.y = 1.4 + sway * 0.4;
+    this.mound.position.x = sway;
+
+    // dust around the cresting head
+    const pos = this.dustPositions;
+    const n = this.dustSeeds.length;
+    for (let i = 0; i < n; i++) {
+      const s = this.dustSeeds[i];
+      const life = (elapsed * (0.6 + s) + s * 7) % 1;
+      pos[i * 3] = (s - 0.5) * 22 + Math.sin(s * 60 + elapsed) * 2;
+      pos[i * 3 + 1] = 2.5 + life * 9;
+      pos[i * 3 + 2] = 8 - life * 36;
+    }
+    this.dust.geometry.attributes.position.needsUpdate = true;
+    (this.dust.material as THREE.PointsMaterial).opacity = this.state === "breach" ? 0.8 : 0.5;
+  }
+
+  private animateBreach(t: number): void {
+    // rise fast, hold, sink back
+    let rise: number;
+    if (t < 0.32) rise = (t / 0.32) * (t / 0.32); // accelerate up
+    else if (t < 0.6) rise = 1;
+    else rise = 1 - (t - 0.6) / 0.4;
+    const h = terrainHeight(this.breachAt.x, this.breachAt.y);
+    this.group.position.set(this.breachAt.x, h, this.breachAt.y);
+    this.body.position.y = lerp(-62, 30, rise);
+    this.body.rotation.z = Math.sin(t * Math.PI) * 0.12;
+    const lean = Math.sin(Math.min(1, t / 0.6) * Math.PI * 0.5) * 0.35;
+    this.body.rotation.x = lean;
+  }
+
+  reset(): void {
+    this.state = "idle";
+    this.target = null;
+    this.satedClock = 0;
+    this.timesCalled = 0;
+    this.group.visible = false;
+    this.body.visible = false;
+    this.mound.visible = true;
+    this.wake.visible = true;
+  }
+}
+
+export const WORM_KILL_RADIUS = KILL_RADIUS;

--- a/src/lib/dune/worm.ts
+++ b/src/lib/dune/worm.ts
@@ -6,6 +6,7 @@
 import * as THREE from "three";
 import { terrainHeight, isOnRock } from "./world";
 import { clamp, lerp } from "./noise";
+import { makeDotTexture } from "./dot-texture";
 
 export type WormState =
   | "idle" // no worm in the area
@@ -57,16 +58,17 @@ export class SandWorm {
     this.group.visible = false;
     scene.add(this.group);
 
-    // --- the moving mound (wormsign)
+    // --- the moving mound (wormsign) — sand-colored so it reads as a
+    // cresting of sand, not a foreign object
     const moundGeo = new THREE.SphereGeometry(1, 24, 16);
-    const moundMat = new THREE.MeshStandardMaterial({ color: 0xc08b52, roughness: 1, flatShading: false });
+    const moundMat = new THREE.MeshStandardMaterial({ color: 0xd49d66, roughness: 1, flatShading: false });
     this.mound = new THREE.Mesh(moundGeo, moundMat);
-    this.mound.scale.set(13, 4.4, 30);
+    this.mound.scale.set(13, 3.8, 30);
     this.group.add(this.mound);
 
-    const wakeMat = new THREE.MeshStandardMaterial({ color: 0xb37f49, roughness: 1, transparent: true, opacity: 0.85 });
+    const wakeMat = new THREE.MeshStandardMaterial({ color: 0xcc965f, roughness: 1, transparent: true, opacity: 0.9 });
     this.wake = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 10), wakeMat);
-    this.wake.scale.set(8, 2.2, 46);
+    this.wake.scale.set(8, 1.9, 46);
     this.wake.position.z = -30;
     this.group.add(this.wake);
 
@@ -78,10 +80,11 @@ export class SandWorm {
     const dustGeo = new THREE.BufferGeometry();
     dustGeo.setAttribute("position", new THREE.BufferAttribute(this.dustPositions, 3));
     const dustMat = new THREE.PointsMaterial({
-      color: 0xd9b07a,
-      size: 1.6,
+      color: 0xd3a877,
+      size: 1.1,
+      map: makeDotTexture(),
       transparent: true,
-      opacity: 0.55,
+      opacity: 0.4,
       depthWrite: false,
       sizeAttenuation: true,
     });
@@ -90,9 +93,9 @@ export class SandWorm {
 
     // --- breaching body: segmented trunk + maw of crystal teeth
     this.body = new THREE.Group();
-    const skin = new THREE.MeshStandardMaterial({ color: 0x8a6a4a, roughness: 0.95 });
-    const skinDark = new THREE.MeshStandardMaterial({ color: 0x6e5238, roughness: 1 });
-    const SEGMENTS = 9;
+    const skin = new THREE.MeshStandardMaterial({ color: 0xa1805c, roughness: 0.92 });
+    const skinDark = new THREE.MeshStandardMaterial({ color: 0x82654a, roughness: 1 });
+    const SEGMENTS = 14;
     for (let i = 0; i < SEGMENTS; i++) {
       const t = i / (SEGMENTS - 1);
       const r = lerp(10.5, 13.5, t);
@@ -133,11 +136,14 @@ export class SandWorm {
   /** Spawn over the horizon, approaching the given target point. */
   call(target: WormTarget, fromAngleHint: number | null = null): void {
     if (this.state === "breach") return;
-    if (this.state === "idle" || this.state === "leave") {
+    if (this.state === "idle") {
       const a = fromAngleHint ?? Math.random() * Math.PI * 2;
       this.pos.set(target.x + Math.cos(a) * SPAWN_DIST, target.z + Math.sin(a) * SPAWN_DIST);
       this.timesCalled++;
       this.group.visible = true;
+    } else if (this.state === "leave") {
+      // a departing worm turns back toward the new summons
+      this.timesCalled++;
     }
     this.target = { ...target };
     this.state = "approach";
@@ -209,7 +215,12 @@ export class SandWorm {
         } else {
           this.state = "breach";
           this.breachClock = 0;
-          this.breachAt.set(this.target.x, this.target.z);
+          // surface a bit short of the prey so the body towers in front of
+          // it (and the camera) instead of erupting through it
+          this.breachAt.set(
+            this.target.x - this.heading.x * 24,
+            this.target.z - this.heading.y * 24
+          );
           this.body.visible = true;
           this.mound.visible = false;
           this.wake.visible = false;
@@ -281,9 +292,12 @@ export class SandWorm {
     else rise = 1 - (t - 0.6) / 0.4;
     const h = terrainHeight(this.breachAt.x, this.breachAt.y);
     this.group.position.set(this.breachAt.x, h, this.breachAt.y);
-    this.body.position.y = lerp(-62, 30, rise);
-    this.body.rotation.z = Math.sin(t * Math.PI) * 0.12;
-    const lean = Math.sin(Math.min(1, t / 0.6) * Math.PI * 0.5) * 0.35;
+    // keep facing the prey (group +z points along the final heading)
+    this.group.rotation.y = Math.atan2(this.heading.x, this.heading.y);
+    this.body.position.y = lerp(-95, 26, rise);
+    this.body.rotation.z = Math.sin(t * Math.PI) * 0.1;
+    // loom: tip the maw forward over the prey so the teeth show
+    const lean = Math.sin(Math.min(1, t / 0.6) * Math.PI * 0.5) * 0.55;
     this.body.rotation.x = lean;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Arrakis: The Crossing (`/dune`)

A first-person, browser-playable 3D survival game built on the desert of Arrakis from Frank Herbert's *Dune*. Your ornithopter is down; cross ~500m of open erg to the sietch cliffs without drawing Shai-Hulud.

## The sandwalk mechanic (book-accurate)

> "We must walk without rhythm… they must sound like the natural shifting of sand… like the wind. Step… drag… drag… step… step… wait… drag… step…" — *Dune*, ch. 21

- **Tap** W/A/S/D for single steps. A rhythm detector measures the coefficient of variation of your step intervals — broken timing reads as natural sand-shift (near-silent), regular tapping reads as **rhythmic** and feeds the vibration meter.
- **Holding** W (steady walk) or **Shift** (run) is inherently rhythmic and loud.
- Past the vibration threshold: **wormsign** — "an elongated mound-in-motion, a cresting of sand" appears on the horizon with dust hiss and rising rumble, homing on your last loud footfall.
- Go still or sandwalk to break the trail (it circles, then departs); if it reaches you on open sand it breaches — crystal-teeth maw — and takes you.
- **Drum sand** patches (pale, taut) boom when stepped on and instantly summon the worm.
- **Thumpers** (T, 2 per crossing) drum "lump… lump" and divert the worm, which breaches and devours them.
- **Rock is safe**: start islet, 3 refuge outcrops, and the sietch cliff line.

## World

Procedural dune field (analytic noise heightfield shared by rendering/physics/AI), dawn sky shader with sun glow, the two moons of Arrakis, stars, low-drifting wind-blown sand, glittering spice blows, sietch cliff massif with glowing cave mouths. Fully procedural WebAudio: gusting wind, footfalls, drum-sand boom, thumper clapper, worm rumble/hiss scaled by proximity, heartbeat under threat.

## Screenshots

[Intro](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F01-intro.png)
[Wormsign warning while walking rhythmically](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F04-wormsign.png)
[The worm](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2Fworm-150m.png)
[Shai-Hulud breaching with crystal teeth](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2Fworm-breach.png)
[Death screen](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F05-death.png)
[Drum sand warning](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F07-drum-sand.png)

## Implementation

- `src/app/dune/page.tsx` — route (client-rendered canvas + DOM HUD)
- `src/components/dune/DuneGame.tsx` — React shell, HUD, intro/death/victory overlays with book quotes and run stats
- `src/lib/dune/` — engine: `game.ts` (scene/player/loop), `worm.ts` (wormsign + breach AI), `rhythm.ts` (step-interval rhythm detector), `world.ts` (heightfield + zones), `audio.ts` (procedural sound), `noise.ts`, `dot-texture.ts`
- Plain `three` (no extra frameworks); deterministic terrain so physics, AI, and rendering always agree

## Testing

`scripts/playtest-dune.mjs` plays the game end-to-end headless (software WebGL):

- intro → start, sandwalk taps stay quiet, no worm
- holding W summons wormsign → worm chase → breach → death screen
- restart resets everything
- thumper diverts an approaching worm; worm devours it and departs sated
- drum sand maxes vibration and summons the worm
- rock refuge: worm balks, player survives
- final stretch sandwalk → victory screen with stats
- screenshot-based render sanity checks

All 30 checks pass. A separate "skilled Fremen" bot validated game balance by legitimately sandwalking a 245m stretch to victory with zero worms drawn (196/204 steps judged sandwalk), which also caught and fixed a balance flaw where proper sandwalking still accumulated vibration.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

