### PR TITLE
Dune game v2: faster rendering, sand-geyser worm, wormsign arrow, Sietch Tabr minimap, ornithopter flight

### DIFF
--- a/scripts/playtest-dune.mjs
+++ b/scripts/playtest-dune.mjs
@@ -8,7 +8,9 @@
 //   6. thumper diverts an approaching worm, worm devours it and leaves
 //   7. drum sand instantly maxes vibration
 //   8. refuge rock = safe; worm balks and circles
-//   9. crossing to the sietch cliffs -> win screen + stats
+//   9. crossing to Sietch Tabr -> win screen + stats + ornithopter unlock
+//  10. flight mode: take off, fly, land
+//  11. worm sandbox at /dune/sandbox: spawn, approach, eruption, reset
 //
 // Usage: node scripts/playtest-dune.mjs [baseURL]
 
@@ -77,6 +79,11 @@ s = await state();
 check("wormsign appears from rhythmic walking", s.worm.state === "approach", `worm=${s.worm.state}`);
 await page.getByTestId("wormsign").waitFor({ state: "visible", timeout: 5000 });
 check("wormsign HUD visible", await page.getByTestId("wormsign").isVisible());
+await page.getByTestId("worm-arrow").waitFor({ state: "visible", timeout: 5000 });
+const arrowTransform = await page.getByTestId("worm-arrow").evaluate((el) => el.style.transform);
+check("directional arrow renders with rotation", /rotate\(-?\d+(\.\d+)?deg\)/.test(arrowTransform), arrowTransform);
+check("bearing matches state", s.worm.bearing !== null, `bearing=${s.worm.bearing}`);
+check("minimap visible", await page.getByTestId("minimap").isVisible());
 await shot("04-wormsign");
 
 console.log("\n=== 4. The worm takes the rhythmic walker ===");
@@ -174,11 +181,58 @@ check("victory", s.phase === "won", `phase=${s.phase} z=${s.z.toFixed(1)}`);
 await page.getByTestId("win-screen").waitFor({ state: "visible", timeout: 5000 });
 check("win screen", await page.getByTestId("win-screen").isVisible());
 check("win stats steps > 0", s.steps > 0);
+check("ornithopter unlocked", s.flightUnlocked === true);
 await shot("09-victory");
 
-console.log("\n=== 10. Visual sanity: canvas actually renders ===");
+console.log("\n=== 10. Ornithopter flight ===");
+await page.getByTestId("fly-button").click();
+await page.waitForFunction(() => window.__DUNE__.getState().phase === "flight", null, { timeout: 5000 });
+await page.getByTestId("flight-alt").waitFor({ state: "visible", timeout: 5000 });
+const before = await state();
+await page.keyboard.down("KeyW"); // throttle up
+await page.keyboard.down("KeyR"); // climb
+await sleep(4000);
+await page.keyboard.up("KeyW");
+await page.keyboard.up("KeyR");
+s = await state();
+check("thopter moves", Math.hypot(s.x - before.x, s.z - before.z) > 40, `moved=${Math.hypot(s.x - before.x, s.z - before.z).toFixed(0)}m`);
+check("thopter climbs", s.altitude > before.altitude + 10, `alt ${before.altitude.toFixed(0)} -> ${s.altitude.toFixed(0)}`);
+// banked turn changes heading
+const yawBefore = await page.evaluate(() => window.__DUNE__.getState());
+await page.keyboard.down("KeyA");
+await sleep(1500);
+await page.keyboard.up("KeyA");
+s = await state();
+check("thopter turns", Math.hypot(s.x - yawBefore.x, s.z - yawBefore.z) > 5, "turned and kept flying");
+await shot("10-flight");
+await page.getByTestId("end-flight").click();
+await sleep(400);
+s = await state();
+check("landing returns to menu", s.phase === "intro");
+await page.getByTestId("intro-fly-button").waitFor({ state: "visible", timeout: 5000 });
+check("intro offers flight once unlocked", await page.getByTestId("intro-fly-button").isVisible());
+
+console.log("\n=== 11. Worm sandbox ===");
+await page.goto(`${BASE}/dune/sandbox`, { waitUntil: "networkidle" });
+await page.waitForFunction(() => window.__DUNE__ !== undefined, null, { timeout: 20000 });
+await sleep(1200);
+check("sandbox phase", (await state()).phase === "sandbox");
+await page.getByTestId("spawn-east").click();
+await page.waitForFunction(() => window.__DUNE__.getState().worm.state === "approach", null, { timeout: 8000 });
+check("sandbox spawn -> approach", true);
+await page.waitForFunction(() => window.__DUNE__.getState().worm.state === "breach", null, { timeout: 90000 });
+check("sandbox approach -> eruption", true);
+await sleep(900);
+await shot("11-sandbox-eruption");
+await page.waitForFunction(() => ["leave", "idle"].includes(window.__DUNE__.getState().worm.state), null, { timeout: 30000 });
+check("sandbox eruption -> departs", true);
+await page.getByTestId("sandbox-reset").click();
+await sleep(300);
+check("sandbox reset", (await state()).worm.state === "idle");
+
+console.log("\n=== 12. Visual sanity: canvas actually renders ===");
 // A black/blank 1280x720 frame compresses to a few KB; a rendered desert is far larger.
-for (const f of ["02-start", "04-wormsign", "07-drum-sand"]) {
+for (const f of ["02-start", "04-wormsign", "07-drum-sand", "10-flight", "11-sandbox-eruption"]) {
   const size = fs.statSync(`${SHOT_DIR}/${f}.png`).size;
   check(`screenshot ${f} is a real render`, size > 60000, `${size} bytes`);
 }

--- a/src/app/dune/sandbox/page.tsx
+++ b/src/app/dune/sandbox/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import DuneGame from "@/components/dune/DuneGame";
+
+export const metadata: Metadata = {
+  title: "Worm Sandbox — Arrakis: The Crossing",
+  description: "Isolated proving ground for Shai-Hulud: wormsign approach and sand eruption.",
+  robots: { index: false },
+};
+
+export default function DuneSandboxPage() {
+  return <DuneGame sandbox />;
+}

--- a/src/components/dune/DuneGame.tsx
+++ b/src/components/dune/DuneGame.tsx
@@ -9,12 +9,22 @@ const INITIAL_HUD: HudState = {
   stepLabel: null,
   wormState: "idle",
   wormDistance: null,
+  wormBearing: null,
   distanceToGoal: 0,
   thumpers: 2,
   onRock: true,
   onSpice: false,
   message: null,
   messageTone: "info",
+  px: 0,
+  pz: 250,
+  yaw: 0,
+  wormX: null,
+  wormZ: null,
+  thumperPos: [],
+  flightUnlocked: false,
+  altitude: 0,
+  airspeed: 0,
   stats: { time: 0, steps: 0, sandwalkSteps: 0, wormsCalled: 0, thumpersUsed: 0 },
 };
 
@@ -24,10 +34,10 @@ function formatTime(s: number): string {
   return `${m}:${sec.toString().padStart(2, "0")}`;
 }
 
-export default function DuneGame() {
+export default function DuneGame({ sandbox = false }: { sandbox?: boolean }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<Engine | null>(null);
-  const [hud, setHud] = useState<HudState>(INITIAL_HUD);
+  const [hud, setHud] = useState<HudState>(sandbox ? { ...INITIAL_HUD, phase: "sandbox" } : INITIAL_HUD);
   const frameSkip = useRef(0);
 
   useEffect(() => {
@@ -35,11 +45,15 @@ export default function DuneGame() {
     let engine: Engine | null = null;
     void import("@/lib/dune/game").then(({ DuneGame: GameEngine }) => {
       if (disposed || !canvasRef.current) return;
-      engine = new GameEngine(canvasRef.current, (h) => {
-        // throttle React updates to ~20fps; the canvas runs at full speed
-        frameSkip.current = (frameSkip.current + 1) % 3;
-        if (frameSkip.current === 0) setHud({ ...h });
-      });
+      engine = new GameEngine(
+        canvasRef.current,
+        (h) => {
+          // throttle React updates to ~20fps; the canvas runs at full speed
+          frameSkip.current = (frameSkip.current + 1) % 3;
+          if (frameSkip.current === 0) setHud({ ...h });
+        },
+        { sandbox }
+      );
       engineRef.current = engine;
     });
     return () => {
@@ -47,7 +61,7 @@ export default function DuneGame() {
       engine?.dispose();
       engineRef.current = null;
     };
-  }, []);
+  }, [sandbox]);
 
   const vibPct = Math.round(hud.vibration * 100);
   const vibColor =
@@ -57,6 +71,9 @@ export default function DuneGame() {
   return (
     <div className="relative h-dvh w-full overflow-hidden bg-black font-sans select-none">
       <canvas ref={canvasRef} className="block h-full w-full" />
+
+      {/* ---------- sandbox controls ---------- */}
+      {sandbox && <SandboxPanel hud={hud} />}
 
       {/* ---------- in-game HUD ---------- */}
       {hud.phase === "playing" && (
@@ -96,7 +113,7 @@ export default function DuneGame() {
           {/* top-left status */}
           <div className="pointer-events-none absolute top-4 left-4 space-y-1 text-[12px] text-amber-50/90">
             <div className="rounded bg-black/40 px-3 py-1.5 backdrop-blur-sm">
-              <span className="tracking-[0.18em] text-amber-200/70 uppercase">Sietch&nbsp;</span>
+              <span className="tracking-[0.18em] text-amber-200/70 uppercase">Sietch Tabr&nbsp;</span>
               <span data-testid="distance" className="font-semibold tabular-nums">
                 {Math.round(hud.distanceToGoal)}m
               </span>
@@ -112,7 +129,10 @@ export default function DuneGame() {
             )}
           </div>
 
-          {/* wormsign warning */}
+          {/* minimap */}
+          <MiniMap hud={hud} />
+
+          {/* wormsign warning + directional arrow */}
           {hud.wormState !== "idle" && (
             <div
               data-testid="wormsign"
@@ -124,8 +144,20 @@ export default function DuneGame() {
                 {hud.wormState === "breach" ? "Shai-Hulud" : "Wormsign"}
               </div>
               {hud.wormDistance !== null && hud.wormState !== "breach" && (
-                <div className="text-sm font-semibold tabular-nums">
-                  {Math.round(hud.wormDistance)}m {hud.wormState === "leave" ? "— departing" : hud.wormState === "search" ? "— circling" : "— approaching"}
+                <div className="flex items-center justify-center gap-2 text-sm font-semibold tabular-nums">
+                  {hud.wormBearing !== null && (
+                    <span
+                      data-testid="worm-arrow"
+                      className={`inline-block text-lg leading-none ${wormNear ? "text-red-300" : "text-orange-300"}`}
+                      style={{ transform: `rotate(${(hud.wormBearing * 180) / Math.PI}deg)` }}
+                    >
+                      ➤
+                    </span>
+                  )}
+                  <span>
+                    {Math.round(hud.wormDistance)}m{" "}
+                    {hud.wormState === "leave" ? "— departing" : hud.wormState === "search" ? "— circling" : "— approaching"}
+                  </span>
                 </div>
               )}
             </div>
@@ -148,13 +180,50 @@ export default function DuneGame() {
           )}
 
           {/* controls hint */}
-          <div className="pointer-events-none absolute right-4 bottom-4 hidden rounded bg-black/35 px-3 py-2 text-right text-[10px] leading-relaxed text-amber-100/50 backdrop-blur-sm sm:block">
+          <div className="pointer-events-none absolute bottom-4 left-4 hidden rounded bg-black/35 px-3 py-2 text-[10px] leading-relaxed text-amber-100/50 backdrop-blur-sm sm:block">
             tap W/A/S/D — irregular single steps (sandwalk)
             <br />
             hold W — steady walk (loud) · Shift — run (very loud)
             <br />
             mouse / Q E — look · T — plant thumper
           </div>
+        </>
+      )}
+
+      {/* ---------- flight HUD ---------- */}
+      {hud.phase === "flight" && (
+        <>
+          <div className="pointer-events-none absolute top-4 left-4 space-y-1 text-[12px] text-sky-50/90">
+            <div className="rounded bg-black/40 px-3 py-1.5 backdrop-blur-sm">
+              <span className="tracking-[0.18em] text-sky-200/70 uppercase">Ornithopter</span>
+            </div>
+            <div className="rounded bg-black/40 px-3 py-1.5 backdrop-blur-sm">
+              <span className="tracking-[0.18em] text-sky-200/70 uppercase">Alt&nbsp;</span>
+              <span data-testid="flight-alt" className="font-semibold tabular-nums">
+                {Math.round(hud.altitude)}m
+              </span>
+              <span className="tracking-[0.18em] text-sky-200/70 uppercase">&nbsp;&nbsp;Spd&nbsp;</span>
+              <span className="font-semibold tabular-nums">{Math.round(hud.airspeed)}</span>
+            </div>
+          </div>
+          <MiniMap hud={hud} />
+          {hud.message && (
+            <div className="pointer-events-none absolute bottom-20 left-1/2 w-[min(560px,86vw)] -translate-x-1/2 rounded bg-emerald-950/60 px-4 py-2 text-center text-[13px] text-emerald-100 backdrop-blur-sm">
+              {hud.message}
+            </div>
+          )}
+          <div className="pointer-events-none absolute bottom-4 left-4 hidden rounded bg-black/35 px-3 py-2 text-[10px] leading-relaxed text-sky-100/50 backdrop-blur-sm sm:block">
+            W/S — throttle · A/D — bank · mouse — pitch
+            <br />
+            R / Space — climb · F / Shift — dive
+          </div>
+          <button
+            data-testid="end-flight"
+            onClick={() => engineRef.current?.endFlight()}
+            className="absolute right-4 bottom-4 cursor-pointer rounded border border-sky-300/40 bg-sky-400/10 px-4 py-2 text-[11px] font-semibold tracking-[0.25em] text-sky-100 uppercase backdrop-blur-sm transition hover:bg-sky-400/25"
+          >
+            Land
+          </button>
         </>
       )}
 
@@ -167,8 +236,9 @@ export default function DuneGame() {
               THE CROSSING
             </h1>
             <p className="mx-auto mt-5 max-w-md text-sm leading-relaxed text-amber-100/85">
-              Your ornithopter is down. The sietch cliffs lie across open erg —
-              worm territory. The sand carries every footfall to Shai-Hulud.
+              Your ornithopter is down. <b className="text-amber-200">Objective: reach Sietch Tabr</b> — the
+              cliff stronghold across the open erg, marked on your minimap. The
+              sand carries every footfall to Shai-Hulud.
             </p>
             <blockquote className="mx-auto mt-4 max-w-md border-l-2 border-amber-400/40 pl-3 text-left text-[13px] text-amber-200/75 italic">
               “We must walk without rhythm… they must sound like the natural
@@ -181,13 +251,24 @@ export default function DuneGame() {
               <div><b className="text-amber-200">T</b> — plant a thumper to lure the worm away.</div>
               <div><b className="text-emerald-300">Rock</b> is safe. Pale taut sand is drum sand — never step on it.</div>
             </div>
-            <button
-              data-testid="start-button"
-              onClick={() => engineRef.current?.start()}
-              className="mt-7 cursor-pointer rounded border border-amber-300/50 bg-amber-400/10 px-10 py-3 text-sm font-semibold tracking-[0.3em] text-amber-100 uppercase transition hover:bg-amber-400/25"
-            >
-              Begin the crossing
-            </button>
+            <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+              <button
+                data-testid="start-button"
+                onClick={() => engineRef.current?.start()}
+                className="cursor-pointer rounded border border-amber-300/50 bg-amber-400/10 px-10 py-3 text-sm font-semibold tracking-[0.3em] text-amber-100 uppercase transition hover:bg-amber-400/25"
+              >
+                Begin the crossing
+              </button>
+              {hud.flightUnlocked && (
+                <button
+                  data-testid="intro-fly-button"
+                  onClick={() => engineRef.current?.startFlight()}
+                  className="cursor-pointer rounded border border-sky-300/50 bg-sky-400/10 px-6 py-3 text-sm font-semibold tracking-[0.3em] text-sky-100 uppercase transition hover:bg-sky-400/25"
+                >
+                  Fly the Ornithopter
+                </button>
+              )}
+            </div>
             <div className="mt-3 text-[11px] text-amber-100/40">click the sand to lock the mouse · headphones recommended</div>
             <div className="mt-2 hidden text-[11px] text-red-300/70 [@media(hover:none)]:block">
               This crossing requires a keyboard — visit on a desktop browser.
@@ -224,25 +305,221 @@ export default function DuneGame() {
       {hud.phase === "won" && (
         <div data-testid="win-screen" className="absolute inset-0 flex items-center justify-center bg-emerald-950/50 p-6 backdrop-blur-[2px]">
           <div className="max-w-lg text-center text-amber-50">
-            <h2 className="font-serif text-4xl font-bold text-emerald-200">YOU REACHED THE SIETCH</h2>
+            <h2 className="font-serif text-4xl font-bold text-emerald-200">SIETCH TABR</h2>
             <p className="mt-4 text-sm text-amber-100/85">
               You crossed the open erg and the worm did not take you. You walked
-              as the Fremen walk — without rhythm, like the shifting of sand.
+              as the Fremen walk — and the sietch opens its doors.
+            </p>
+            <p className="mt-2 text-sm font-semibold text-sky-200">
+              The Fremen grant you a restored ornithopter. Flight over Arrakis is unlocked.
             </p>
             <blockquote className="mt-3 text-[13px] text-amber-200/70 italic">
               “God created Arrakis to train the faithful.”
             </blockquote>
             <StatsBlock hud={hud} />
-            <button
-              data-testid="restart-button"
-              onClick={() => engineRef.current?.restart()}
-              className="mt-6 cursor-pointer rounded border border-emerald-300/50 bg-emerald-400/10 px-8 py-3 text-sm font-semibold tracking-[0.3em] text-emerald-100 uppercase transition hover:bg-emerald-400/25"
-            >
-              Cross again
-            </button>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+              <button
+                data-testid="fly-button"
+                onClick={() => engineRef.current?.startFlight()}
+                className="cursor-pointer rounded border border-sky-300/50 bg-sky-400/15 px-8 py-3 text-sm font-semibold tracking-[0.3em] text-sky-100 uppercase transition hover:bg-sky-400/30"
+              >
+                Take the Ornithopter
+              </button>
+              <button
+                data-testid="restart-button"
+                onClick={() => engineRef.current?.restart()}
+                className="cursor-pointer rounded border border-emerald-300/50 bg-emerald-400/10 px-6 py-3 text-sm font-semibold tracking-[0.3em] text-emerald-100 uppercase transition hover:bg-emerald-400/25"
+              >
+                Cross again
+              </button>
+            </div>
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------ minimap
+
+const MAP_W = 138;
+const MAP_H = 168;
+const WORLD_X = [-260, 260];
+const WORLD_Z = [-340, 340];
+
+function toMap(x: number, z: number): [number, number] {
+  const mx = ((x - WORLD_X[0]) / (WORLD_X[1] - WORLD_X[0])) * MAP_W;
+  const my = ((z - WORLD_Z[0]) / (WORLD_Z[1] - WORLD_Z[0])) * MAP_H;
+  return [mx, my];
+}
+
+/** Static layer: sand, hazards, refuges, the sietch — drawn once. */
+function drawMapBase(g: CanvasRenderingContext2D, world: typeof import("@/lib/dune/world")) {
+  g.fillStyle = "#8a6238";
+  g.fillRect(0, 0, MAP_W, MAP_H);
+  // spice
+  for (const p of world.SPICE_PATCHES) {
+    const [x, y] = toMap(p.x, p.z);
+    g.fillStyle = "rgba(170,80,30,0.75)";
+    g.beginPath();
+    g.arc(x, y, (p.r / 520) * MAP_W, 0, Math.PI * 2);
+    g.fill();
+  }
+  // drum sand
+  for (const p of world.DRUM_PATCHES) {
+    const [x, y] = toMap(p.x, p.z);
+    g.fillStyle = "rgba(238,226,190,0.92)";
+    g.beginPath();
+    g.arc(x, y, (p.r / 520) * MAP_W, 0, Math.PI * 2);
+    g.fill();
+  }
+  // refuges + start
+  g.fillStyle = "#3c322b";
+  for (const rf of [world.START, ...world.REFUGES]) {
+    const [x, y] = toMap(rf.x, rf.z);
+    g.beginPath();
+    g.arc(x, y, Math.max(2.5, (rf.r / 520) * MAP_W), 0, Math.PI * 2);
+    g.fill();
+  }
+  // the sietch cliff band
+  const [, cy] = toMap(0, world.GOAL_Z);
+  g.fillStyle = "#332a24";
+  g.fillRect(0, 0, MAP_W, cy);
+  g.fillStyle = "#ffb45e";
+  g.beginPath();
+  g.arc(MAP_W / 2, cy - 5, 2.6, 0, Math.PI * 2);
+  g.fill();
+  g.font = "7px sans-serif";
+  g.textAlign = "center";
+  g.fillStyle = "#ffd9a0";
+  g.fillText("SIETCH TABR", MAP_W / 2, cy - 10);
+}
+
+function MiniMap({ hud }: { hud: HudState }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  const baseRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void import("@/lib/dune/world").then((world) => {
+      if (cancelled) return;
+      const base = document.createElement("canvas");
+      base.width = MAP_W;
+      base.height = MAP_H;
+      drawMapBase(base.getContext("2d")!, world);
+      baseRef.current = base;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const c = ref.current;
+    const base = baseRef.current;
+    if (!c || !base) return;
+    const g = c.getContext("2d")!;
+    g.clearRect(0, 0, MAP_W, MAP_H);
+    g.drawImage(base, 0, 0);
+    // thumpers
+    g.fillStyle = "#ffd84a";
+    for (const th of hud.thumperPos) {
+      const [x, y] = toMap(th.x, th.z);
+      g.beginPath();
+      g.arc(x, y, 2, 0, Math.PI * 2);
+      g.fill();
+    }
+    // worm
+    if (hud.wormX !== null && hud.wormZ !== null) {
+      const [x, y] = toMap(hud.wormX, hud.wormZ);
+      const r = 3 + Math.sin(Date.now() / 160) * 1.2;
+      g.fillStyle = "#e23b25";
+      g.beginPath();
+      g.arc(Math.max(2, Math.min(MAP_W - 2, x)), Math.max(2, Math.min(MAP_H - 2, y)), r, 0, Math.PI * 2);
+      g.fill();
+    }
+    // player arrow
+    const [px, py] = toMap(hud.px, hud.pz);
+    g.save();
+    g.translate(px, py);
+    g.rotate(-hud.yaw);
+    g.fillStyle = "#e8f3ff";
+    g.beginPath();
+    g.moveTo(0, -5);
+    g.lineTo(3.4, 4);
+    g.lineTo(-3.4, 4);
+    g.closePath();
+    g.fill();
+    g.restore();
+  }, [hud]);
+
+  return (
+    <div className="pointer-events-none absolute top-4 right-4 rounded border border-amber-100/20 bg-black/45 p-1.5 backdrop-blur-sm">
+      <canvas data-testid="minimap" ref={ref} width={MAP_W} height={MAP_H} className="block rounded-sm opacity-90" />
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------ sandbox
+
+declare global {
+  interface Window {
+    __DUNE__?: {
+      sandbox?: {
+        spawn: (angleDeg: number, dist?: number) => void;
+        breach: () => void;
+        reset: () => void;
+      };
+    };
+  }
+}
+
+function SandboxPanel({ hud }: { hud: HudState }) {
+  const call = (fn: (sb: NonNullable<NonNullable<Window["__DUNE__"]>["sandbox"]>) => void) => {
+    const sb = window.__DUNE__?.sandbox;
+    if (sb) fn(sb);
+  };
+  return (
+    <div className="absolute top-4 left-4 w-60 space-y-2 rounded bg-black/60 p-3 text-[12px] text-amber-50 backdrop-blur-sm">
+      <div className="text-[11px] tracking-[0.3em] text-amber-300/80 uppercase">Worm Sandbox</div>
+      <div data-testid="sandbox-state" className="font-mono text-amber-200">
+        state: {hud.wormState}
+        {hud.wormX !== null &&
+          hud.wormZ !== null &&
+          ` · ${Math.round(Math.hypot(hud.wormX - 0, hud.wormZ - 60))}m`}
+      </div>
+      <div className="grid grid-cols-2 gap-1.5">
+        {[
+          ["North", 270],
+          ["East", 0],
+          ["South", 90],
+          ["West", 180],
+        ].map(([label, deg]) => (
+          <button
+            key={label}
+            data-testid={`spawn-${String(label).toLowerCase()}`}
+            onClick={() => call((sb) => sb.spawn(Number(deg)))}
+            className="cursor-pointer rounded border border-amber-300/40 bg-amber-400/10 px-2 py-1.5 hover:bg-amber-400/25"
+          >
+            Approach {label}
+          </button>
+        ))}
+        <button
+          data-testid="sandbox-breach"
+          onClick={() => call((sb) => sb.breach())}
+          className="col-span-2 cursor-pointer rounded border border-red-300/40 bg-red-400/10 px-2 py-1.5 text-red-200 hover:bg-red-400/25"
+        >
+          Instant eruption
+        </button>
+        <button
+          data-testid="sandbox-reset"
+          onClick={() => call((sb) => sb.reset())}
+          className="col-span-2 cursor-pointer rounded border border-amber-100/30 px-2 py-1.5 hover:bg-white/10"
+        >
+          Reset
+        </button>
+      </div>
+      <div className="text-[10px] text-amber-100/50">Camera orbits the proving ground automatically.</div>
     </div>
   );
 }

--- a/src/lib/dune/audio.ts
+++ b/src/lib/dune/audio.ts
@@ -16,6 +16,7 @@ export class DuneAudio {
   private hissGain: GainNode | null = null;
   private heartTimer = 0;
   private thumperTimer = 0;
+  private flapNodes: { src: AudioBufferSourceNode; lfo: OscillatorNode; out: GainNode } | null = null;
 
   get ready(): boolean {
     return this.ctx !== null;
@@ -147,6 +148,48 @@ export class DuneAudio {
     g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
     src.connect(f).connect(g).connect(this.master);
     src.start(ctx.currentTime, Math.random() * 1.2, dur + 0.05);
+  }
+
+  /** Ornithopter wing-beat: noise pulsed by a low-frequency oscillator. */
+  setFlight(active: boolean): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.master || !this.noiseBuf) return;
+    if (active && !this.flapNodes) {
+      const src = ctx.createBufferSource();
+      src.buffer = this.noiseBuf;
+      src.loop = true;
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = 180;
+      bp.Q.value = 1.1;
+      const mod = ctx.createGain();
+      mod.gain.value = 0.12; // base whoosh
+      const lfo = ctx.createOscillator();
+      lfo.type = "sine";
+      lfo.frequency.value = 5.2; // wing beats per second
+      const depth = ctx.createGain();
+      depth.gain.value = 0.1;
+      lfo.connect(depth).connect(mod.gain);
+      const out = ctx.createGain();
+      out.gain.value = 0.0001;
+      src.connect(bp).connect(mod).connect(out).connect(this.master);
+      src.start();
+      lfo.start();
+      out.gain.exponentialRampToValueAtTime(1, ctx.currentTime + 1.2);
+      this.flapNodes = { src, lfo, out };
+    } else if (!active && this.flapNodes) {
+      const { src, lfo, out } = this.flapNodes;
+      this.flapNodes = null;
+      out.gain.setTargetAtTime(0.0001, ctx.currentTime, 0.25);
+      setTimeout(() => {
+        try {
+          src.stop();
+          lfo.stop();
+        } catch {
+          // already stopped
+        }
+      }, 900);
+    }
   }
 
   footstep(kind: "step" | "walk" | "run" | "drag"): void {

--- a/src/lib/dune/game.ts
+++ b/src/lib/dune/game.ts
@@ -2,6 +2,7 @@
 // (sandwalk mechanics), the worm, thumpers, ambience and the HUD feed.
 
 import * as THREE from "three";
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import {
   WORLD_SIZE,
   START,
@@ -24,7 +25,7 @@ import { makeDotTexture } from "./dot-texture";
 import { SandWorm, WormState, WORM_KILL_RADIUS } from "./worm";
 import { DuneAudio } from "./audio";
 
-export type Phase = "intro" | "playing" | "dead" | "won";
+export type Phase = "intro" | "playing" | "dead" | "won" | "flight" | "sandbox";
 
 export interface HudState {
   phase: Phase;
@@ -32,12 +33,25 @@ export interface HudState {
   stepLabel: "sandwalk" | "uneven" | "rhythmic" | null;
   wormState: WormState;
   wormDistance: number | null;
+  /** angle of the worm relative to where the player faces; 0 = dead ahead, +cw */
+  wormBearing: number | null;
   distanceToGoal: number;
   thumpers: number;
   onRock: boolean;
   onSpice: boolean;
   message: string | null;
   messageTone: "info" | "danger" | "good";
+  // minimap feed
+  px: number;
+  pz: number;
+  yaw: number;
+  wormX: number | null;
+  wormZ: number | null;
+  thumperPos: { x: number; z: number }[];
+  // ornithopter
+  flightUnlocked: boolean;
+  altitude: number;
+  airspeed: number;
   stats: {
     time: number;
     steps: number;
@@ -57,9 +71,28 @@ interface Thumper {
   tick: number;
 }
 
+/** True when WebGL falls back to a software rasterizer (SwiftShader etc.). */
+function isSoftwareGL(): boolean {
+  try {
+    const c = document.createElement("canvas");
+    const gl = c.getContext("webgl2") ?? c.getContext("webgl");
+    if (!gl) return true;
+    const ext = gl.getExtension("WEBGL_debug_renderer_info");
+    const name = String(
+      ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER)
+    ).toLowerCase();
+    return /swiftshader|software|llvmpipe|softpipe/.test(name);
+  } catch {
+    return false;
+  }
+}
+
 const PLAYER_EYE = 1.7;
 const FRICTION = 5.5;
 const VIBRATION_TRIGGER = 0.55;
+const UNLOCK_KEY = "dune_ornithopter_unlocked";
+/** open-sand vantage used by the worm sandbox */
+const SANDBOX_POINT = { x: 0, z: 60 };
 
 export class DuneGame {
   private renderer: THREE.WebGLRenderer;
@@ -98,8 +131,15 @@ export class DuneGame {
   private spicePoints!: THREE.Points;
   private skyMat!: THREE.ShaderMaterial;
 
+  // ornithopter flight
+  private flightSpeed = 32;
+  private flightY = 0;
+  private bank = 0;
+  private flightUnlocked = false;
+
   // state
   phase: Phase = "intro";
+  private sandboxMode = false;
   private startTime = 0;
   private steps = 0;
   private sandwalkSteps = 0;
@@ -113,10 +153,25 @@ export class DuneGame {
   hud: HudState;
   onHud: (h: HudState) => void;
 
-  constructor(canvas: HTMLCanvasElement, onHud: (h: HudState) => void) {
+  constructor(canvas: HTMLCanvasElement, onHud: (h: HudState) => void, opts?: { sandbox?: boolean }) {
     this.onHud = onHud;
-    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.sandboxMode = opts?.sandbox ?? false;
+    if (this.sandboxMode) this.phase = "sandbox";
+    try {
+      this.flightUnlocked = localStorage.getItem(UNLOCK_KEY) === "1";
+    } catch {
+      this.flightUnlocked = false;
+    }
+    // MSAA only on low-dpi displays with real GPUs: high-dpi supersampling
+    // already smooths edges, and software rasterizers pay dearly for MSAA.
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    this.renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: dpr < 1.5 && !isSoftwareGL(),
+      powerPreference: "high-performance",
+      stencil: false,
+    });
+    this.renderer.setPixelRatio(dpr);
     this.renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     this.renderer.toneMappingExposure = 1.05;
@@ -141,12 +196,12 @@ export class DuneGame {
 
     this.worm = new SandWorm(this.scene);
     this.worm.onBreachStart = (x, z, kind) => {
-      this.shake = Math.max(this.shake, kind === "player" ? 1.4 : 0.7);
+      this.shake = Math.max(this.shake, kind === "player" ? 1.6 : 0.7);
       this.audio.wormBreach();
       if (kind === "player") {
-        this.showMessage("Shai-Hulud rises — a gaping round mouth, crystal teeth glinting!", "danger", 4);
+        this.showMessage("THE SAND ERUPTS — Shai-Hulud strikes from below!", "danger", 4);
       } else {
-        this.showMessage("The Maker breaches and takes the thumper.", "info", 4);
+        this.showMessage("Sand geysers skyward — the Maker takes the thumper.", "info", 4);
       }
     };
     this.worm.onBreachHit = (x, z, kind, thumperId) => {
@@ -301,7 +356,7 @@ export class DuneGame {
 
       // drum sand: paler, smoother, slightly grey — visibly taut
       const df = drumFactor(x, z);
-      if (df > 0) cBase.lerp(new THREE.Color(0.97, 0.94, 0.82), df * 0.95);
+      if (df > 0) cBase.lerp(new THREE.Color(0.95, 0.9, 0.74), df * 0.92);
 
       // spice: rust-cinnamon stain
       const sf = spiceFactor(x, z);
@@ -322,18 +377,31 @@ export class DuneGame {
     const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 1, metalness: 0 });
     this.scene.add(new THREE.Mesh(geo, mat));
 
-    // endless-erg illusion: a vast sand disc under and beyond the heightfield
+    // endless-erg illusion: a sand annulus from the heightfield edge outward
+    // (a ring, not a disc, so it never overdraws the detailed terrain)
     const far = new THREE.Mesh(
-      new THREE.CircleGeometry(4200, 48),
-      new THREE.MeshStandardMaterial({ color: 0xc1854e, roughness: 1 })
+      new THREE.RingGeometry(WORLD_SIZE / 2 - 60, 4200, 48, 1),
+      new THREE.MeshStandardMaterial({ color: 0xcc9158, roughness: 1 })
     );
     far.rotation.x = -Math.PI / 2;
-    far.position.y = -7; // below the heightfield's lowest valley
+    far.position.y = -5;
     this.scene.add(far);
   }
 
   private buildRocks(): void {
+    // every boulder and crag baked into ONE geometry -> a single draw call
     const rockMat = new THREE.MeshStandardMaterial({ color: 0x5d4e41, roughness: 0.95, flatShading: true });
+    const parts: THREE.BufferGeometry[] = [];
+    const bake = (geo: THREE.BufferGeometry, m: THREE.Matrix4) => {
+      const g = geo.toNonIndexed();
+      g.applyMatrix4(m);
+      parts.push(g);
+      geo.dispose();
+    };
+    const tmp = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+
     const addBoulders = (cx: number, cz: number, r: number, count: number, keepExitClear: boolean) => {
       for (let i = 0; i < count; i++) {
         const a = Math.random() * Math.PI * 2;
@@ -343,11 +411,13 @@ export class DuneGame {
         const x = cx + Math.cos(a) * rr;
         const z = cz + Math.sin(a) * rr;
         const s = 0.8 + Math.random() * 2.2;
-        const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(s, 0), rockMat);
-        rock.position.set(x, terrainHeight(x, z) + s * 0.2, z);
-        rock.rotation.set(Math.random() * 3, Math.random() * 3, Math.random() * 3);
-        rock.scale.y = 0.6 + Math.random() * 0.5;
-        this.scene.add(rock);
+        q.setFromEuler(e.set(Math.random() * 3, Math.random() * 3, Math.random() * 3));
+        tmp.compose(
+          new THREE.Vector3(x, terrainHeight(x, z) + s * 0.2, z),
+          q,
+          new THREE.Vector3(1, 0.6 + Math.random() * 0.5, 1)
+        );
+        bake(new THREE.DodecahedronGeometry(s, 0), tmp);
       }
     };
     addBoulders(START.x, START.z, START.r, 16, true);
@@ -357,12 +427,17 @@ export class DuneGame {
       const x = -700 + Math.random() * 1400;
       const z = CLIFF_Z - 90 - Math.random() * 160;
       const s = 16 + Math.random() * 42;
-      const crag = new THREE.Mesh(new THREE.ConeGeometry(s * (1.3 + Math.random() * 0.9), s * (1.4 + Math.random()), 6), rockMat);
-      crag.position.set(x, terrainHeight(x, z) + s * 0.35, z);
-      crag.rotation.y = Math.random() * 3;
-      crag.scale.x = 1 + Math.random() * 1.4;
-      this.scene.add(crag);
+      q.setFromEuler(e.set(0, Math.random() * 3, 0));
+      tmp.compose(
+        new THREE.Vector3(x, terrainHeight(x, z) + s * 0.35, z),
+        q,
+        new THREE.Vector3(1 + Math.random() * 1.4, 1, 1)
+      );
+      bake(new THREE.ConeGeometry(s * (1.3 + Math.random() * 0.9), s * (1.4 + Math.random()), 6), tmp);
     }
+    const merged = mergeGeometries(parts);
+    merged.computeVertexNormals();
+    this.scene.add(new THREE.Mesh(merged, rockMat));
   }
 
   private buildSietchGlow(): void {
@@ -454,7 +529,7 @@ export class DuneGame {
   }
 
   private onCanvasClick = (): void => {
-    if (this.phase !== "playing") return;
+    if (this.phase !== "playing" && this.phase !== "flight") return;
     const canvas = this.renderer.domElement;
     if (document.pointerLockElement !== canvas) {
       canvas.requestPointerLock?.()?.catch?.(() => {});
@@ -491,7 +566,7 @@ export class DuneGame {
     this.hud.stepLabel = judge.label;
 
     // movement impulse in look direction
-    const impulse = kind === "run" ? 9.2 : kind === "walk" ? 6.6 : 7.6;
+    const impulse = kind === "run" ? 9.6 : kind === "walk" ? 6.8 : 8.4;
     const sin = Math.sin(this.yaw);
     const cos = Math.cos(this.yaw);
     const wx = dir.x * cos + dir.y * sin;
@@ -593,9 +668,9 @@ export class DuneGame {
     this.phase = "playing";
     this.startTime = this.elapsed;
     this.showMessage(
-      "Cross the open sand. Tap to step — keep your timing broken, like wind-shifted sand.",
+      "OBJECTIVE: reach Sietch Tabr — the cliffs marked on your minimap. Tap to step; keep your timing broken.",
       "info",
-      6
+      7
     );
   }
 
@@ -634,6 +709,80 @@ export class DuneGame {
     this.phase = "won";
     this.audio.win();
     document.exitPointerLock?.();
+    // Sietch Tabr grants its prize: the ornithopter
+    this.flightUnlocked = true;
+    try {
+      localStorage.setItem(UNLOCK_KEY, "1");
+    } catch {
+      // private browsing: unlock lasts for this session only
+    }
+  }
+
+  // ------------------------------------------------------------- flight
+
+  startFlight(): void {
+    if (!this.flightUnlocked) return;
+    this.audio.init();
+    this.phase = "flight";
+    this.pos.set(0, 0, GOAL_Z - 30);
+    this.flightY = terrainHeight(this.pos.x, this.pos.z) + 34;
+    this.flightSpeed = 32;
+    this.bank = 0;
+    this.yaw = Math.PI; // lift off facing back over the open erg
+    this.pitch = 0;
+    this.worm.reset();
+    this.audio.setFlight(true);
+    this.showMessage("Wings hammer the dawn air — Arrakis unrolls beneath you.", "good", 6);
+  }
+
+  endFlight(): void {
+    if (this.phase !== "flight") return;
+    this.audio.setFlight(false);
+    this.phase = "intro";
+    document.exitPointerLock?.();
+  }
+
+  private updateFlight(dt: number, t: number): void {
+    const has = (...ks: string[]) => ks.some((k) => this.keys.has(k));
+    // throttle
+    if (has("KeyW", "ArrowUp")) this.flightSpeed += 32 * dt;
+    if (has("KeyS", "ArrowDown")) this.flightSpeed -= 36 * dt;
+    this.flightSpeed = clamp(this.flightSpeed, 14, 96);
+    // banking turns
+    let bankTarget = 0;
+    if (has("KeyA", "ArrowLeft", "KeyQ")) {
+      this.yaw += 1.35 * dt;
+      bankTarget = 0.42;
+    }
+    if (has("KeyD", "ArrowRight", "KeyE")) {
+      this.yaw -= 1.35 * dt;
+      bankTarget = -0.42;
+    }
+    this.bank = lerp(this.bank, bankTarget, 1 - Math.exp(-4.5 * dt));
+    // climb / dive: pitch from the mouse plus direct lift keys
+    let vy = Math.sin(this.pitch) * this.flightSpeed;
+    if (has("KeyR", "Space")) vy += 22;
+    if (has("KeyF", "ShiftLeft", "ShiftRight")) vy -= 22;
+
+    const fx = -Math.sin(this.yaw) * Math.cos(this.pitch);
+    const fz = -Math.cos(this.yaw) * Math.cos(this.pitch);
+    this.pos.x += fx * this.flightSpeed * dt;
+    this.pos.z += fz * this.flightSpeed * dt;
+    this.flightY += vy * dt;
+    // keep over the rendered erg, above the dunes, below the haze ceiling
+    this.pos.x = clamp(this.pos.x, -1700, 1700);
+    this.pos.z = clamp(this.pos.z, -1700, 1700);
+    const minY = terrainHeight(this.pos.x, this.pos.z) + 7;
+    this.flightY = clamp(this.flightY, minY, 420);
+
+    // wing-beat bob + bank roll
+    const flap = Math.sin(t * 10.5) * 0.3;
+    this.camera.position.set(this.pos.x, this.flightY + flap, this.pos.z);
+    const lookX = this.pos.x - Math.sin(this.yaw) * Math.cos(this.pitch);
+    const lookY = this.camera.position.y + Math.sin(this.pitch);
+    const lookZ = this.pos.z - Math.cos(this.yaw) * Math.cos(this.pitch);
+    this.camera.lookAt(lookX, lookY, lookZ);
+    this.camera.rotateZ(this.bank);
   }
 
   private showMessage(text: string, tone: "info" | "danger" | "good", dur: number): void {
@@ -642,12 +791,24 @@ export class DuneGame {
     this.messageTtl = dur;
   }
 
+  private decayTimers(dt: number): void {
+    if (this.stepLabelTtl > 0) {
+      this.stepLabelTtl -= dt;
+      if (this.stepLabelTtl <= 0) this.hud.stepLabel = null;
+    }
+    if (this.messageTtl > 0) {
+      this.messageTtl -= dt;
+      if (this.messageTtl <= 0) this.message = null;
+    }
+  }
+
   // ---------------------------------------------------------------- loop
 
   private loop = (): void => {
     if (this.disposed) return;
     this.raf = requestAnimationFrame(this.loop);
-    const dt = Math.min(0.05, this.clock.getDelta());
+    // generous clamp: even at ~10fps the game runs at real-time speed
+    const dt = Math.min(0.1, this.clock.getDelta());
     this.elapsed += dt;
     this.update(dt);
     this.renderer.render(this.scene, this.camera);
@@ -664,6 +825,26 @@ export class DuneGame {
       const cz = START.z - 60 + Math.cos(a * 0.7) * 30;
       this.camera.position.set(cx, terrainHeight(cx, cz) + 16, cz);
       this.camera.lookAt(0, 8, GOAL_Z);
+      this.updateAmbient(dt, t);
+      return;
+    }
+
+    if (this.phase === "sandbox") {
+      // slow orbit around the proving ground so the worm can be inspected
+      const a = t * 0.1;
+      const cx = SANDBOX_POINT.x + Math.sin(a) * 95;
+      const cz = SANDBOX_POINT.z + Math.cos(a) * 95;
+      this.camera.position.set(cx, terrainHeight(cx, cz) + 26, cz);
+      this.camera.lookAt(SANDBOX_POINT.x, terrainHeight(SANDBOX_POINT.x, SANDBOX_POINT.z) + 5, SANDBOX_POINT.z);
+      this.worm.update(dt, t, SANDBOX_POINT.x, SANDBOX_POINT.z);
+      this.decayTimers(dt);
+      this.updateAmbient(dt, t);
+      return;
+    }
+
+    if (this.phase === "flight") {
+      this.updateFlight(dt, t);
+      this.decayTimers(dt);
       this.updateAmbient(dt, t);
       return;
     }
@@ -722,14 +903,7 @@ export class DuneGame {
     const onRock = isOnRock(this.pos.x, this.pos.z);
     this.vibration = clamp(this.vibration - dt * (onRock ? 0.16 : 0.075), 0, 1);
 
-    if (this.stepLabelTtl > 0) {
-      this.stepLabelTtl -= dt;
-      if (this.stepLabelTtl <= 0) this.hud.stepLabel = null;
-    }
-    if (this.messageTtl > 0) {
-      this.messageTtl -= dt;
-      if (this.messageTtl <= 0) this.message = null;
-    }
+    this.decayTimers(dt);
 
     // spice flavor
     if (isOnSpice(this.pos.x, this.pos.z)) {
@@ -830,6 +1004,17 @@ export class DuneGame {
 
   // ---------------------------------------------------------------- hud
 
+  /** Worm direction relative to facing: 0 = ahead, +cw (right), ±PI = behind. */
+  private wormBearing(): number | null {
+    if (this.worm.state === "idle" || this.worm.state === "breach") return null;
+    const dx = this.worm.pos.x - this.pos.x;
+    const dz = this.worm.pos.y - this.pos.z;
+    let b = this.yaw + Math.PI - Math.atan2(dx, dz);
+    while (b > Math.PI) b -= Math.PI * 2;
+    while (b < -Math.PI) b += Math.PI * 2;
+    return b;
+  }
+
   private makeHud(): HudState {
     const wormActive = this.worm.state !== "idle";
     return {
@@ -838,12 +1023,22 @@ export class DuneGame {
       stepLabel: this.stepLabelTtl > 0 ? this.hud?.stepLabel ?? null : null,
       wormState: this.worm.state,
       wormDistance: wormActive ? this.worm.distanceTo(this.pos.x, this.pos.z) : null,
+      wormBearing: this.wormBearing(),
       distanceToGoal: Math.max(0, this.pos.z - (GOAL_Z + 5)),
       thumpers: this.thumperInventory,
       onRock: isOnRock(this.pos.x, this.pos.z),
       onSpice: isOnSpice(this.pos.x, this.pos.z),
       message: this.message,
       messageTone: this.messageTone,
+      px: this.pos.x,
+      pz: this.pos.z,
+      yaw: this.yaw,
+      wormX: wormActive ? this.worm.pos.x : null,
+      wormZ: wormActive ? this.worm.pos.y : null,
+      thumperPos: this.thumpers.map((th) => ({ x: th.x, z: th.z })),
+      flightUnlocked: this.flightUnlocked,
+      altitude: this.phase === "flight" ? this.flightY - terrainHeight(this.pos.x, this.pos.z) : 0,
+      airspeed: this.phase === "flight" ? this.flightSpeed : 0,
       stats: {
         time: this.phase === "intro" ? 0 : this.elapsed - this.startTime,
         steps: this.steps,
@@ -868,6 +1063,7 @@ export class DuneGame {
           x: this.worm.pos.x,
           z: this.worm.pos.y,
           dist: this.worm.state !== "idle" ? this.worm.distanceTo(this.pos.x, this.pos.z) : null,
+          bearing: this.wormBearing(),
           timesCalled: this.worm.timesCalled,
         },
         thumpers: this.thumperInventory,
@@ -876,9 +1072,18 @@ export class DuneGame {
         steps: this.steps,
         sandwalkSteps: this.sandwalkSteps,
         message: this.message,
+        flightUnlocked: this.flightUnlocked,
+        altitude: this.phase === "flight" ? this.flightY - terrainHeight(this.pos.x, this.pos.z) : 0,
+        airspeed: this.flightSpeed,
+        flightY: this.flightY,
       }),
       start: () => this.start(),
       restart: () => this.restart(),
+      startFlight: () => this.startFlight(),
+      endFlight: () => this.endFlight(),
+      unlockFlight: () => {
+        this.flightUnlocked = true;
+      },
       teleport: (x: number, z: number) => {
         this.pos.set(x, 0, z);
         this.vel.set(0, 0, 0);
@@ -890,6 +1095,24 @@ export class DuneGame {
         this.vibration = clamp(v, 0, 1);
       },
       plantThumper: () => this.plantThumper(),
+      sandbox: {
+        /** summon a worm that approaches the proving point from a compass angle */
+        spawn: (angleDeg: number, dist = 320) => {
+          this.worm.reset();
+          this.worm.call(
+            { x: SANDBOX_POINT.x, z: SANDBOX_POINT.z, kind: "player" },
+            (angleDeg * Math.PI) / 180
+          );
+          this.worm.placeAt(dist, (angleDeg * Math.PI) / 180);
+        },
+        /** drop the worm right next to the point for an instant eruption */
+        breach: () => {
+          this.worm.reset();
+          this.worm.call({ x: SANDBOX_POINT.x, z: SANDBOX_POINT.z, kind: "player" }, 0);
+          this.worm.placeAt(20, 0);
+        },
+        reset: () => this.worm.reset(),
+      },
     };
     (window as unknown as Record<string, unknown>).__DUNE__ = api;
   }

--- a/src/lib/dune/worm.ts
+++ b/src/lib/dune/worm.ts
@@ -1,18 +1,18 @@
 // Shai-Hulud. While travelling it shows only wormsign: "an elongated
 // mound-in-motion — a cresting of sand" trailing a dust hiss. When it reaches
-// rhythmic vibration on open sand it breaches: a vast round mouth ringed with
-// crystal teeth.
+// rhythmic vibration on open sand the desert itself erupts — a violent geyser
+// of sand and dust blasting skyward where the prey stood.
 
 import * as THREE from "three";
 import { terrainHeight, isOnRock } from "./world";
-import { clamp, lerp } from "./noise";
+import { clamp } from "./noise";
 import { makeDotTexture } from "./dot-texture";
 
 export type WormState =
   | "idle" // no worm in the area
   | "approach" // homing on a vibration source
   | "search" // lost the trail, casting about
-  | "breach" // surfacing attack animation
+  | "breach" // surfacing attack: the sand eruption
   | "leave"; // departing / sated
 
 export interface WormTarget {
@@ -26,8 +26,12 @@ const SPAWN_DIST = 620;
 const DESPAWN_DIST = 950;
 const SEARCH_TIME = 11;
 const BREACH_TRIGGER_DIST = 16;
-const BREACH_DURATION = 2.6;
+const BREACH_DURATION = 3.8;
 const KILL_RADIUS = 30;
+
+const ERUPT_N = 1400;
+const ERUPT_STAGGER = 1.4; // particles launch over this many seconds
+const GRAVITY = 24;
 
 export class SandWorm {
   state: WormState = "idle";
@@ -44,10 +48,17 @@ export class SandWorm {
   group: THREE.Group;
   private mound: THREE.Mesh;
   private wake: THREE.Mesh;
-  private body: THREE.Group;
   private dust: THREE.Points;
   private dustPositions: Float32Array;
   private dustSeeds: Float32Array;
+
+  // the eruption: a staggered ballistic sand geyser + rising dust billows
+  private erupt: THREE.Points;
+  private eruptMat: THREE.PointsMaterial;
+  private eruptPositions: Float32Array;
+  private eruptVel: Float32Array; // vx, vy, vz per particle
+  private eruptDelay: Float32Array;
+  private billows: THREE.Sprite[] = [];
 
   onBreachStart: ((x: number, z: number, kind: "player" | "thumper") => void) | null = null;
   onBreachHit: ((x: number, z: number, kind: "player" | "thumper", thumperId?: number) => void) | null = null;
@@ -61,7 +72,7 @@ export class SandWorm {
     // --- the moving mound (wormsign) — sand-colored so it reads as a
     // cresting of sand, not a foreign object
     const moundGeo = new THREE.SphereGeometry(1, 24, 16);
-    const moundMat = new THREE.MeshStandardMaterial({ color: 0xd49d66, roughness: 1, flatShading: false });
+    const moundMat = new THREE.MeshStandardMaterial({ color: 0xd49d66, roughness: 1 });
     this.mound = new THREE.Mesh(moundGeo, moundMat);
     this.mound.scale.set(13, 3.8, 30);
     this.group.add(this.mound);
@@ -91,46 +102,36 @@ export class SandWorm {
     this.dust = new THREE.Points(dustGeo, dustMat);
     this.group.add(this.dust);
 
-    // --- breaching body: segmented trunk + maw of crystal teeth
-    this.body = new THREE.Group();
-    const skin = new THREE.MeshStandardMaterial({ color: 0xa1805c, roughness: 0.92 });
-    const skinDark = new THREE.MeshStandardMaterial({ color: 0x82654a, roughness: 1 });
-    const SEGMENTS = 14;
-    for (let i = 0; i < SEGMENTS; i++) {
-      const t = i / (SEGMENTS - 1);
-      const r = lerp(10.5, 13.5, t);
-      const seg = new THREE.Mesh(new THREE.CylinderGeometry(r, r * 1.04, 6.4, 28), i % 2 ? skin : skinDark);
-      seg.position.y = -i * 6.1;
-      this.body.add(seg);
+    // --- eruption particles (world-space, independent of the group)
+    this.eruptPositions = new Float32Array(ERUPT_N * 3);
+    this.eruptVel = new Float32Array(ERUPT_N * 3);
+    this.eruptDelay = new Float32Array(ERUPT_N);
+    const eg = new THREE.BufferGeometry();
+    eg.setAttribute("position", new THREE.BufferAttribute(this.eruptPositions, 3));
+    this.eruptMat = new THREE.PointsMaterial({
+      color: 0xc59a63,
+      size: 4.4,
+      map: makeDotTexture(),
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false,
+      sizeAttenuation: true,
+    });
+    this.erupt = new THREE.Points(eg, this.eruptMat);
+    this.erupt.visible = false;
+    this.erupt.frustumCulled = false;
+    scene.add(this.erupt);
+
+    // --- big soft dust billows that swell out of the eruption
+    const billowTex = makeDotTexture();
+    for (let i = 0; i < 4; i++) {
+      const sp = new THREE.Sprite(
+        new THREE.SpriteMaterial({ map: billowTex, color: 0xc69a66, transparent: true, opacity: 0, depthWrite: false })
+      );
+      sp.visible = false;
+      scene.add(sp);
+      this.billows.push(sp);
     }
-    // the maw
-    const maw = new THREE.Group();
-    const throat = new THREE.Mesh(
-      new THREE.CylinderGeometry(8.2, 2.4, 10, 24),
-      new THREE.MeshBasicMaterial({ color: 0x140a06 })
-    );
-    throat.position.y = 1.0;
-    maw.add(throat);
-    const lip = new THREE.Mesh(new THREE.TorusGeometry(10.6, 2.6, 14, 30), skin);
-    lip.rotation.x = Math.PI / 2;
-    lip.position.y = 5.4;
-    maw.add(lip);
-    const toothMat = new THREE.MeshStandardMaterial({ color: 0xf2ead8, roughness: 0.35, metalness: 0.1 });
-    const TEETH = 26;
-    for (let ring = 0; ring < 2; ring++) {
-      const rr = ring === 0 ? 8.6 : 6.2;
-      for (let i = 0; i < TEETH; i++) {
-        const a = (i / TEETH) * Math.PI * 2 + ring * 0.12;
-        const tooth = new THREE.Mesh(new THREE.ConeGeometry(0.85, 4.4, 6), toothMat);
-        tooth.position.set(Math.cos(a) * rr, 4.6 - ring * 1.6, Math.sin(a) * rr);
-        tooth.lookAt(0, -4, 0);
-        maw.add(tooth);
-      }
-    }
-    maw.position.y = 6.0;
-    this.body.add(maw);
-    this.body.visible = false;
-    this.group.add(this.body);
   }
 
   /** Spawn over the horizon, approaching the given target point. */
@@ -168,16 +169,21 @@ export class SandWorm {
     return (x, z) => Math.hypot(this.pos.x - x, this.pos.y - z);
   }
 
+  /** Jump the worm to a given distance from its target (sandbox/testing). */
+  placeAt(dist: number, angle: number): void {
+    if (!this.target) return;
+    this.pos.set(this.target.x + Math.cos(angle) * dist, this.target.z + Math.sin(angle) * dist);
+  }
+
   update(dt: number, elapsed: number, playerX: number, playerZ: number): void {
     if (this.satedClock > 0) this.satedClock -= dt;
     if (this.state === "idle") return;
 
     if (this.state === "breach") {
       this.breachClock += dt;
-      const t = this.breachClock / BREACH_DURATION;
-      this.animateBreach(clamp(t, 0, 1));
+      this.updateEruption(this.breachClock);
       if (this.breachClock > 0.85 && this.breachClock - dt <= 0.85) {
-        // the strike lands
+        // the strike lands beneath the geyser
         this.onBreachHit?.(
           this.breachAt.x,
           this.breachAt.y,
@@ -185,10 +191,12 @@ export class SandWorm {
           this.target?.thumperId
         );
       }
-      if (t >= 1) {
-        this.body.visible = false;
+      if (this.breachClock >= BREACH_DURATION) {
+        this.erupt.visible = false;
+        for (const b of this.billows) b.visible = false;
         this.mound.visible = true;
         this.wake.visible = true;
+        this.group.visible = true;
         this.satedClock = 14;
         this.state = "leave";
         this.target = null;
@@ -213,18 +221,7 @@ export class SandWorm {
           this.state = "search";
           this.searchClock = 0;
         } else {
-          this.state = "breach";
-          this.breachClock = 0;
-          // surface a bit short of the prey so the body towers in front of
-          // it (and the camera) instead of erupting through it
-          this.breachAt.set(
-            this.target.x - this.heading.x * 24,
-            this.target.z - this.heading.y * 24
-          );
-          this.body.visible = true;
-          this.mound.visible = false;
-          this.wake.visible = false;
-          this.onBreachStart?.(this.target.x, this.target.z, this.target.kind);
+          this.startBreach();
         }
       }
     } else if (this.state === "search") {
@@ -260,45 +257,109 @@ export class SandWorm {
       this.pos.y = -230;
     }
 
-    // place wormsign on the terrain
+    // place wormsign on the terrain, pitched to follow the dune slope so the
+    // long mound never floats above a downhill face
     const h = terrainHeight(this.pos.x, this.pos.y);
-    this.group.position.set(this.pos.x, h - 1.5, this.pos.y);
+    const ahead = terrainHeight(this.pos.x + this.heading.x * 22, this.pos.y + this.heading.y * 22);
+    const behind = terrainHeight(this.pos.x - this.heading.x * 22, this.pos.y - this.heading.y * 22);
+    this.group.position.set(this.pos.x, Math.min(h, (ahead + behind) / 2) - 2.2, this.pos.y);
     const angle = Math.atan2(this.heading.x, this.heading.y);
     this.group.rotation.y = angle;
+    this.group.rotation.x = Math.atan2(behind - ahead, 44) * 0.8;
     // mound undulates as it swims
     const sway = Math.sin(elapsed * 3.1) * 0.5;
     this.mound.position.y = 1.4 + sway * 0.4;
     this.mound.position.x = sway;
 
-    // dust around the cresting head
+    // dust around the cresting head — sprays harder the closer it gets
+    const near = this.target
+      ? clamp(1 - this.distanceTo(this.target.x, this.target.z) / 260, 0, 1)
+      : 0;
     const pos = this.dustPositions;
     const n = this.dustSeeds.length;
+    const lift = 9 + near * 13;
     for (let i = 0; i < n; i++) {
       const s = this.dustSeeds[i];
       const life = (elapsed * (0.6 + s) + s * 7) % 1;
       pos[i * 3] = (s - 0.5) * 22 + Math.sin(s * 60 + elapsed) * 2;
-      pos[i * 3 + 1] = 2.5 + life * 9;
+      pos[i * 3 + 1] = 2.5 + life * lift;
       pos[i * 3 + 2] = 8 - life * 36;
     }
     this.dust.geometry.attributes.position.needsUpdate = true;
-    (this.dust.material as THREE.PointsMaterial).opacity = this.state === "breach" ? 0.8 : 0.5;
+    (this.dust.material as THREE.PointsMaterial).opacity = 0.45 + near * 0.3;
   }
 
-  private animateBreach(t: number): void {
-    // rise fast, hold, sink back
-    let rise: number;
-    if (t < 0.32) rise = (t / 0.32) * (t / 0.32); // accelerate up
-    else if (t < 0.6) rise = 1;
-    else rise = 1 - (t - 0.6) / 0.4;
-    const h = terrainHeight(this.breachAt.x, this.breachAt.y);
-    this.group.position.set(this.breachAt.x, h, this.breachAt.y);
-    // keep facing the prey (group +z points along the final heading)
-    this.group.rotation.y = Math.atan2(this.heading.x, this.heading.y);
-    this.body.position.y = lerp(-95, 26, rise);
-    this.body.rotation.z = Math.sin(t * Math.PI) * 0.1;
-    // loom: tip the maw forward over the prey so the teeth show
-    const lean = Math.sin(Math.min(1, t / 0.6) * Math.PI * 0.5) * 0.55;
-    this.body.rotation.x = lean;
+  private startBreach(): void {
+    if (!this.target) return;
+    this.state = "breach";
+    this.breachClock = 0;
+    this.breachAt.set(this.target.x, this.target.z);
+    this.group.visible = false; // the mound vanishes — then the sand explodes
+
+    // seed the geyser
+    const gy = terrainHeight(this.breachAt.x, this.breachAt.y);
+    for (let i = 0; i < ERUPT_N; i++) {
+      const a = Math.random() * Math.PI * 2;
+      const r = Math.sqrt(Math.random()) * 7;
+      this.eruptPositions[i * 3] = this.breachAt.x + Math.cos(a) * r;
+      this.eruptPositions[i * 3 + 1] = gy - 6; // hidden under the sand until launch
+      this.eruptPositions[i * 3 + 2] = this.breachAt.y + Math.sin(a) * r;
+      const ha = Math.random() * Math.PI * 2;
+      const hm = 3 + Math.random() * 14; // outward scatter
+      this.eruptVel[i * 3] = Math.cos(ha) * hm;
+      this.eruptVel[i * 3 + 1] = 26 + Math.random() * 34; // skyward blast
+      this.eruptVel[i * 3 + 2] = Math.sin(ha) * hm;
+      this.eruptDelay[i] = Math.random() * ERUPT_STAGGER;
+    }
+    this.erupt.visible = true;
+    this.eruptMat.opacity = 0.95;
+
+    for (let b = 0; b < this.billows.length; b++) {
+      const sp = this.billows[b];
+      sp.visible = true;
+      sp.material.opacity = 0;
+      sp.position.set(
+        this.breachAt.x + (Math.random() - 0.5) * 10,
+        gy + 2,
+        this.breachAt.y + (Math.random() - 0.5) * 10
+      );
+      sp.scale.set(4, 4, 1);
+    }
+
+    this.onBreachStart?.(this.breachAt.x, this.breachAt.y, this.target.kind);
+  }
+
+  private updateEruption(t: number): void {
+    const gy = terrainHeight(this.breachAt.x, this.breachAt.y);
+    const fade = t > BREACH_DURATION - 0.7 ? (BREACH_DURATION - t) / 0.7 : 1;
+    this.eruptMat.opacity = 0.95 * clamp(fade, 0, 1);
+    for (let i = 0; i < ERUPT_N; i++) {
+      const life = t - this.eruptDelay[i];
+      if (life <= 0) continue;
+      const a = Math.atan2(
+        this.eruptPositions[i * 3 + 2] - this.breachAt.y,
+        this.eruptPositions[i * 3] - this.breachAt.x
+      );
+      const r = Math.hypot(
+        this.eruptPositions[i * 3] - this.breachAt.x,
+        this.eruptPositions[i * 3 + 2] - this.breachAt.y
+      );
+      const y = gy + this.eruptVel[i * 3 + 1] * life - 0.5 * GRAVITY * life * life;
+      this.eruptPositions[i * 3] = this.breachAt.x + Math.cos(a) * r + this.eruptVel[i * 3] * life * 0.18;
+      this.eruptPositions[i * 3 + 2] = this.breachAt.y + Math.sin(a) * r + this.eruptVel[i * 3 + 2] * life * 0.18;
+      this.eruptPositions[i * 3 + 1] = Math.max(y, gy - 6);
+    }
+    this.erupt.geometry.attributes.position.needsUpdate = true;
+
+    // dust billows swell and linger
+    for (let b = 0; b < this.billows.length; b++) {
+      const sp = this.billows[b];
+      const phase = clamp((t - b * 0.22) / (BREACH_DURATION - 0.3), 0, 1);
+      const grow = 8 + phase * (42 + b * 9);
+      sp.scale.set(grow, grow * 0.85, 1);
+      sp.position.y = gy + 5 + phase * (20 + b * 5);
+      sp.material.opacity = Math.sin(phase * Math.PI) * 0.55;
+    }
   }
 
   reset(): void {
@@ -307,7 +368,8 @@ export class SandWorm {
     this.satedClock = 0;
     this.timesCalled = 0;
     this.group.visible = false;
-    this.body.visible = false;
+    this.erupt.visible = false;
+    for (const b of this.billows) b.visible = false;
     this.mound.visible = true;
     this.wake.visible = true;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Arrakis: The Crossing — round 2 (`/dune`)

Builds on the merged v1 (#14) with four upgrades, each validated end-to-end headless.

## 1. Performance (no quality loss)

- All ~100 boulder/crag meshes merged into a **single geometry** → one draw call
- MSAA only on low-DPI displays with hardware GL; software rasterizers (SwiftShader/llvmpipe) detected and excluded
- Far-field rendered as a **ring**, not a disc — no overdraw beneath the detailed heightfield
- `powerPreference: high-performance`, stencil off
- `dt` clamp raised so gameplay stays **real-time even at 10 FPS** (no more slow-motion on weak machines)
- Headless software-GL benchmark: **10.3 → 14.4 FPS (+40%)**; real GPUs additionally gain the draw-call reduction

## 2. Worm rework + sandbox

- The trunk/maw model is gone. When Shai-Hulud reaches you, **the desert explodes**: a staggered ballistic sand geyser (1400 gravity-driven particles) plus swelling dust billows erupt beneath you — pure fear factor, no janky model.
- While it approaches, the wormsign HUD shows a **directional arrow** that rotates to point where the worm is coming from relative to your facing (red when close), plus a live red dot on the minimap.
- The travelling mound now **pitches to follow dune slopes** (it used to float over downhill faces) and sprays dust harder as it closes in.
- New isolated proving ground at **`/dune/sandbox`**: orbiting camera, buttons to summon the worm from N/E/S/W, instant eruption, reset — used to validate every visual with fixed screenshots.

## 3. Objective: Sietch Tabr + minimap

- Intro, HUD and win screen now name the objective: **reach Sietch Tabr**
- Live **minimap**: sietch marker + label, drum-sand patches, spice blows, rock refuges, player heading arrow, active thumpers, hunting worm
- Crossing takes ~3 minutes at a careful sandwalk — comfortably under 5

## 4. Ornithopter flight mode

- Winning at Sietch Tabr **unlocks the ornithopter** (persisted in localStorage; also launchable from the intro once unlocked)
- Arcade flight over the open erg: W/S throttle, A/D **banking turns**, mouse pitch, R/Space climb, F/Shift dive
- Wing-beat audio (LFO-pulsed noise), altitude/speed HUD, minimap, Land button returns to menu

## Screenshots

[Wormsign with directional arrow and minimap](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F04-wormsign.png)
[Slope-hugging mound at 60m in the sandbox](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2Fsb-mound-60.png)
[Sand geyser engulfing the view](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2Fsb-erupt-mid.png)
[Sandbox eruption column](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F11-sandbox-eruption.png)
[Ornithopter banking over the dunes](https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdune%2F10-flight.png)

## Testing

`scripts/playtest-dune.mjs` now runs **47 checks across 12 scenarios**: sandwalk stealth, wormsign + arrow + bearing + minimap, death by eruption, restart, thumper diversion, drum sand, rock refuge, victory + ornithopter unlock, full flight cycle (move/climb/turn/land/re-fly from intro), sandbox spawn→approach→eruption→depart→reset, and screenshot render sanity. **All pass**, plus lint, typecheck, and production build (`/dune` and `/dune/sandbox` both static).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-482aa21e-d2a7-4dd7-8d63-3b229c2ddf93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

